### PR TITLE
meson: Explicity link to dl and threads (Fixes Slackware build)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+  - Explicitly link to dl and thread (Fix Slackware build)
+
 2025-07-13
 
 - dealers-choice 0.0.6:

--- a/meson.build
+++ b/meson.build
@@ -89,6 +89,12 @@ dep_names = [
   'SDL2_image',
 ]
 
+# On Slackware, the miniaudio build fails (linking) if dl and threads aren't added here
+if host_sys == 'linux'
+  shared_dep += [cc.find_library('dl')]
+  dep_names += ['threads']
+endif
+
 foreach dep : dep_names
   shared_dep += dependency(dep)
 endforeach


### PR DESCRIPTION
Although these are specified these in the miniaudio cmake

```
if (UNIX)
    list(APPEND COMMON_LINK_LIBRARIES dl)      # For dlopen(), etc. Most compilers will link to this by default, but some may not.
    list(APPEND COMMON_LINK_LIBRARIES pthread)
```

And there's no problem on the other distros I tried, When building on Slackware I get linking errors.