### PR TITLE
CI/cirrus.yml: Lower-case sdl2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,7 +18,7 @@ common_meson_steps: &common_meson_steps
 common_freebsd_steps: &common_freebsd_steps
   pkginstall_script:
     - pkg update -f
-    - pkg install -y git cmake gettext meson ninja pkgconf protobuf-c python3 SDL2 sdl2_image sdl2_net sdl2_ttf
+    - pkg install -y git cmake gettext meson ninja pkgconf protobuf-c python3 sdl2 sdl2_image sdl2_net sdl2_ttf
 
 freebsd_task:
   <<: *filter_template


### PR DESCRIPTION
Upper-case has been working for months, but I'm gonna try switching it to fix the current error (pkg: No packages available to install matching 'SDL2' have been found in the repositories)
https://www.freshports.org/devel/sdl20