### PR TITLE
Add Windows Inno Setup installer to the build pipeline (closes #68)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,6 +4,12 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'version number'
+        required: false
+        type: string
   push:
     branches: [ trunk ]
     paths: &shared_paths
@@ -19,6 +25,10 @@ on:
 jobs:
   MSYS2:
     runs-on: windows-latest
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ inputs.version }}
     strategy:
       matrix:
         platform: ['UCRT64', 'CLANG64']
@@ -59,3 +69,75 @@ jobs:
       continue-on-error: false
       run: |
         PYTHONUTF8=1 meson test --no-stdsplit -v -C _build
+
+    - name: Stage installer files
+      if: matrix.platform == 'UCRT64'
+      shell: msys2 {0}
+      run: |
+        mkdir -p _staging/data
+        cp _build/dealers-choice.exe _staging/
+        cp -r data/images data/sounds _staging/data/
+        cp data/*.ttf data/server.conf _staging/data/
+        bash packaging/windows/collect-dlls.sh _staging/dealers-choice.exe _staging/
+
+    - name: Set version
+      if: matrix.platform == 'UCRT64'
+      shell: bash
+      run: |
+        if [[ -z "${VERSION}" ]]; then
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
+          else
+            VERSION="snapshot"
+          fi
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+        fi
+
+    - name: Build installer
+      if: matrix.platform == 'UCRT64'
+      shell: pwsh
+      run: |
+        iscc /DVERSION=$env:VERSION packaging\windows\dealers-choice.iss
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+    - name: Checksum
+      if: matrix.platform == 'UCRT64'
+      shell: pwsh
+      run: |
+        $file = "dealers-choice-$env:VERSION-setup.exe"
+        $hash = (Get-FileHash $file -Algorithm SHA256).Hash.ToLower()
+        "$hash  $file" | Out-File -Encoding ascii "$file.sha256sum"
+
+    - name: Upload artifact
+      if: matrix.platform == 'UCRT64' && github.ref != 'refs/heads/trunk'
+      uses: actions/upload-artifact@v7
+      with:
+        name: dealers-choice-windows-installer
+        path: dealers-choice-${{ env.VERSION }}-setup.exe*
+        if-no-files-found: error
+
+    - name: Prerelease (trunk)
+      if: matrix.platform == 'UCRT64' && github.ref == 'refs/heads/trunk'
+      uses: ncipollo/release-action@v1
+      with:
+        artifacts: "dealers-choice-${{ env.VERSION }}-setup.exe*"
+        body: "Dealer's Choice Snapshot Release"
+        allowUpdates: true
+        prerelease: true
+        removeArtifacts: false
+        replacesArtifacts: true
+        omitBodyDuringUpdate: true
+        omitNameDuringUpdate: true
+        tag: snapshot
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Release (tagged)
+      if: matrix.platform == 'UCRT64' && startsWith(github.ref, 'refs/tags/')
+      uses: ncipollo/release-action@v1
+      with:
+        artifacts: "dealers-choice-${{ env.VERSION }}-setup.exe*"
+        allowUpdates: true
+        prerelease: false
+        omitBodyDuringUpdate: true
+        omitNameDuringUpdate: true
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/packaging/windows/collect-dlls.sh
+++ b/packaging/windows/collect-dlls.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Collect runtime DLLs needed by dealers-choice.exe from the MSYS2 installation.
+# Run this from the repository root inside an MSYS2 shell after building.
+# Usage: bash packaging/windows/collect-dlls.sh <exe> <dest-dir>
+
+set -euo pipefail
+
+EXE="${1:?Usage: $0 <exe> <dest-dir>}"
+DEST="${2:?Usage: $0 <exe> <dest-dir>}"
+
+mkdir -p "$DEST"
+
+# ldd prints lines like:
+#   libSDL2-2.0-0.dll => /ucrt64/bin/libSDL2-2.0-0.dll (0x...)
+# We keep only DLLs that live inside the MSYS2 tree (not C:/Windows/...).
+ldd "$EXE" \
+  | grep -i '=> /' \
+  | grep -v '/c/[Ww]indows' \
+  | awk '{print $3}' \
+  | while read -r dll; do
+      if [ -f "$dll" ]; then
+        echo "Copying: $dll"
+        cp "$dll" "$DEST/"
+      fi
+    done

--- a/packaging/windows/dealers-choice.iss
+++ b/packaging/windows/dealers-choice.iss
@@ -1,0 +1,46 @@
+#define AppName    "Dealer's Choice"
+#define AppExe     "dealers-choice.exe"
+#define Publisher  "Dealer's Choice Project"
+#define AppURL     "https://dealer-s-choice.github.io/"
+#define IssuesURL  "https://github.com/Dealer-s-Choice/dealers-choice/issues"
+
+#ifndef VERSION
+  #define VERSION "0.0.0"
+#endif
+
+[Setup]
+AppName={#AppName}
+AppVersion={#VERSION}
+AppPublisher={#Publisher}
+AppPublisherURL={#AppURL}
+AppSupportURL={#IssuesURL}
+AppUpdatesURL={#AppURL}
+DefaultDirName={autopf}\{#AppName}
+DefaultGroupName={#AppName}
+; Output goes to the repo root (script is in packaging/windows/)
+OutputDir=..\..\
+OutputBaseFilename=dealers-choice-{#VERSION}-setup
+Compression=lzma
+SolidCompression=yes
+WizardStyle=modern
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Files]
+; Executable
+Source: "..\..\_staging\{#AppExe}"; DestDir: "{app}"; Flags: ignoreversion
+; Runtime DLLs collected by collect-dlls.sh
+Source: "..\..\_staging\*.dll";     DestDir: "{app}"; Flags: ignoreversion
+; Game data (fonts, images, sounds, server.conf)
+Source: "..\..\_staging\data\*"; DestDir: "{app}\data"; \
+  Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\{#AppName}";           Filename: "{app}\{#AppExe}"
+Name: "{group}\Uninstall {#AppName}"; Filename: "{uninstallexe}"
+
+[Run]
+Filename: "{app}\{#AppExe}"; \
+  Description: "Launch {#AppName}"; \
+  Flags: nowait postinstall skipifsilent

--- a/src/util.c
+++ b/src/util.c
@@ -63,6 +63,21 @@ void get_data_dir(Path_t *path) {
     snprintf(path->data, sizeof path->data, "%s", datadir);
     return;
   }
+
+#ifdef _WIN32
+  // Look for data/ next to the executable — correct for installed builds.
+  char exe_path[MAX_PATH];
+  if (GetModuleFileNameA(NULL, exe_path, sizeof exe_path) != 0) {
+    char *last_sep = strrchr(exe_path, '\\');
+    if (last_sep) {
+      *last_sep = '\0';
+      snprintf(path->data, sizeof path->data, "%s\\data", exe_path);
+      if (check_pathname_state(path->data) == PATH_EXISTS)
+        return;
+    }
+  }
+#endif
+
   // This will be changed before the first release. We'll look here and
   if (check_pathname_state("../data") == PATH_EXISTS) {
     strcpy(path->data, "../data");


### PR DESCRIPTION
- Add packaging/windows/dealers-choice.iss: Inno Setup script that
  installs the executable, runtime DLLs, and data directory; creates
  Start Menu shortcuts and an uninstaller
- Add packaging/windows/collect-dlls.sh: MSYS2 helper script that uses
  ldd to collect non-system runtime DLLs into the staging directory
- Update .github/workflows/windows.yml: add installer build steps
  (UCRT64 only) with version detection, iscc invocation, SHA256
  checksum, and artifact/release upload matching the AppImage workflow
- Fix src/util.c: resolve data directory relative to the executable on
  Windows using GetModuleFileNameA so installed builds find their data
  regardless of working directory

Closes #68