### PR TITLE
tests: initialise SDL and SDLNet in network test setup

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -56,6 +56,6 @@ jobs:
 
     - name: Test
       shell: msys2 {0}
-      continue-on-error: true
+      continue-on-error: false
       run: |
-        meson test --no-stdsplit -v -C _build
+        PYTHONUTF8=1 meson test --no-stdsplit -v -C _build

--- a/src/util.c
+++ b/src/util.c
@@ -153,6 +153,12 @@ int make_directory_recursive(const char *path) {
   if (len > 1 && tmp[len - 1] == PATH_SEP)
     tmp[len - 1] = '\0';
 
+#ifdef _WIN32
+  // Stop recursion at a Windows drive root ("C:" or "C:\") — cannot mkdir it.
+  if (tmp[1] == ':' && (tmp[2] == '\0' || (tmp[2] == PATH_SEP && tmp[3] == '\0')))
+    return 0;
+#endif
+
   // Recursively create parent directory
   char *slash = strrchr(tmp, PATH_SEP);
   if (slash) {

--- a/tests/00_test.h
+++ b/tests/00_test.h
@@ -35,7 +35,8 @@ extern int n_passes;
   for (int i = 0; i < N_PLAYERS; i++) {                                                            \
     socket_cleanup(&socket_context[i]);                                                            \
   }                                                                                                \
-  SDLNet_Quit();
+  SDLNet_Quit();                                                                                   \
+  SDL_Quit();
 
 #define _RECEIVE_GAME_STATE()                                                                      \
   SDL_Delay(n_ms);                                                                                 \
@@ -49,6 +50,10 @@ extern int n_passes;
   }
 
 #define _SETUP_SOCKET_CONTEXT()                                                                    \
+  if (SDL_Init(0) == -1 || SDLNet_Init() == -1) {                                                 \
+    fprintf(stderr, "SDL/SDLNet init failed: %s\n", SDL_GetError());                              \
+    return 1;                                                                                      \
+  }                                                                                                \
   GameSettings_t game_settings[N_PLAYERS] = {0};                                                   \
   GameState_t game_state[N_PLAYERS] = {0};                                                         \
   ClientState_t client_state[N_PLAYERS] = {0};                                                     \


### PR DESCRIPTION
_SETUP_SOCKET_CONTEXT() called SDLNet_ResolveHost / SDLNet_TCP_Open without first calling SDL_Init() or SDLNet_Init(). On Windows, SDLNet_Init() calls WSAStartup() which is required before any Winsock API is used; without it every socket call fails with "Couldn't create socket", causing all network tests to fail.

Also add SDL_Quit() to _SOCKET_CLEANUP_AND_NET_QUIT_ to mirror the new SDL_Init() call.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Fixes #115