### PR TITLE
feat: Add InputWidget_t for validated text input

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -42,6 +42,7 @@
 #include "links.h"
 #include "main.h"
 #include "server.h"
+#include "widgets/input.h"
 
 enum { RUN_CLIENT = 20 };
 
@@ -56,26 +57,22 @@ static int menu_display_connect(PlayerConfig_t *player_config, char *host_str, c
   button_connect.rect.x = x_margin;
   button_connect.rect.y = g_viewport.y + 160;
 
-  int text_w, text_h;
+  int input_w;
+  if (TTF_SizeUTF8(font->fonts[FONT_DEFAULT], "255.255.255.255", &input_w, NULL) != 0)
+    input_w = 150;
+  input_w += 20;
 
-  if (TTF_SizeUTF8(font->fonts[FONT_DEFAULT], "255.255.255.255", &text_w, &text_h) != 0) {
-    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "TTF_SizeUTF8 failed: %s", TTF_GetError());
+  InputWidget_t *host_input =
+      input_widget_create(host_str, font->fonts[FONT_DEFAULT], input_w, CFG_TYPE_STRING);
+  if (!host_input)
+    return 0;
+  host_input->base.rect.x = x_margin;
+  host_input->base.rect.y = g_viewport.y + 220;
+  host_input->focused = true;
 
-    /* fallback size */
-    text_w = 150;
-    text_h = 20;
-  }
-  SDL_Rect input_box = {x_margin, g_viewport.y + 220, text_w + 20, text_h + 16};
+  SDL_Rect port_rect = {x_margin, host_input->base.rect.y + host_input->base.rect.h + 12, 0, 0};
+  SDL_Rect input_nick_pos = {x_margin, g_viewport.y + 380, 0, 0};
 
-  SDL_Rect input_text_pos = {input_box.x + 10, input_box.y + (input_box.h - text_h) / 2, 0, 0};
-
-  SDL_Rect port_rect = {input_box.x, input_box.y + 60, 0, 0};
-
-  // TODO: Create a 'input_box' struct similar to CardContext_t. It will
-  // be used for inputs such as the host ip, nick, and port
-  // This isn't actually an input yet.
-  SDL_Rect input_nick = (SDL_Rect){x_margin, g_viewport.y + 380, 300, 40};
-  SDL_Rect input_nick_pos = {input_nick.x, input_nick.y, 0, 0};
   SDL_StartTextInput();
 
   layout_links(links, LINK_DEFS_COUNT);
@@ -102,9 +99,7 @@ static int menu_display_connect(PlayerConfig_t *player_config, char *host_str, c
               fputs(SDL_GetError(), stderr);
         }
       } else if (e.type == SDL_TEXTINPUT) {
-        if (strlen(host_str) + strlen(e.text.text) < MAX_INPUT_LENGTH) {
-          strcat(host_str, e.text.text);
-        }
+        input_widget_append(host_input, e.text.text);
       } else if (e.type == SDL_KEYDOWN) {
         switch (e.key.keysym.sym) {
         case SDLK_RETURN:
@@ -121,8 +116,7 @@ static int menu_display_connect(PlayerConfig_t *player_config, char *host_str, c
           break;
 
         case SDLK_BACKSPACE:
-          if (strlen(host_str) > 0)
-            host_str[strlen(host_str) - 1] = '\0';
+          input_widget_backspace(host_input);
           break;
 
         default:
@@ -134,11 +128,7 @@ static int menu_display_connect(PlayerConfig_t *player_config, char *host_str, c
     clear_screen(sdl_context->renderer);
     render_button(&button_connect);
 
-    SDL_SetRenderDrawColor(sdl_context->renderer, 255, 255, 255, 255);
-    draw_rect_border(sdl_context->renderer, input_box);
-
-    render_text(sdl_context->renderer, font->fonts[FONT_DEFAULT], host_str, get_color(COLOR_WHITE),
-                &input_text_pos);
+    ui_widget_render(&host_input->base);
 
     char port_str[24] = {0};
     snprintf(port_str, sizeof(port_str), _("port: %" PRIu16), port);
@@ -165,6 +155,14 @@ static int menu_display_connect(PlayerConfig_t *player_config, char *host_str, c
   }
 
   SDL_StopTextInput();
+
+  /* Copy the final text back to host_str before destroying the widget */
+  const char *final = input_widget_get_text(host_input);
+  strncpy(host_str, final, MAX_INPUT_LENGTH - 1);
+  host_str[MAX_INPUT_LENGTH - 1] = '\0';
+
+  ui_widget_destroy(&host_input->base);
+
   return run_client == true ? RUN_CLIENT : 0;
 }
 

--- a/src/widgets/input.c
+++ b/src/widgets/input.c
@@ -1,0 +1,166 @@
+#include "input.h"
+#include "globals.h"
+
+#define CURSOR_BLINK_MS 500
+
+/* Returns true if every character in `text` is acceptable for the given type. */
+static bool chars_allowed(const char *text, ConfigType type, const char *current_buf) {
+  for (const char *p = text; *p; p++) {
+    switch (type) {
+    case CFG_TYPE_INT:
+      /* Allow a leading '-' only when the buffer is currently empty */
+      if (*p == '-' && p == text && current_buf[0] == '\0')
+        continue;
+      if (*p < '0' || *p > '9')
+        return false;
+      break;
+    case CFG_TYPE_UINT8:
+    case CFG_TYPE_UINT16:
+    case CFG_TYPE_UINT32:
+      if (*p < '0' || *p > '9')
+        return false;
+      break;
+    case CFG_TYPE_BOOL:
+      /* Accept y/n/t/f/1/0 (case-insensitive first char) */
+      {
+        char c = (*p >= 'A' && *p <= 'Z') ? (*p + 32) : *p;
+        if (c != 'y' && c != 'n' && c != 't' && c != 'f' && c != '1' && c != '0')
+          return false;
+      }
+      break;
+    case CFG_TYPE_STRING:
+    default:
+      /* Accept any printable ASCII (SDL text input already filters most junk) */
+      if ((unsigned char)*p < 0x20)
+        return false;
+      break;
+    }
+  }
+  return true;
+}
+
+static void input_widget_render(UIWidget_t *w) {
+  InputWidget_t *iw = (InputWidget_t *)w;
+  SDL_Renderer *r = g_sdl_context->renderer;
+
+  /* Background */
+  SDL_SetRenderDrawColor(r, 30, 30, 30, 255);
+  SDL_RenderFillRect(r, &w->rect);
+
+  /* Border: yellow when focused, white otherwise */
+  SDL_Color border_color = iw->focused ? (SDL_Color){255, 220, 0, 255} : (SDL_Color){200, 200, 200, 255};
+  SDL_SetRenderDrawColor(r, border_color.r, border_color.g, border_color.b, border_color.a);
+  SDL_RenderDrawRect(r, &w->rect);
+  /* Double border when focused */
+  if (iw->focused) {
+    SDL_Rect inner = {w->rect.x + 1, w->rect.y + 1, w->rect.w - 2, w->rect.h - 2};
+    SDL_RenderDrawRect(r, &inner);
+  }
+
+  /* Text */
+  int text_x = w->rect.x + 8;
+
+  if (iw->len > 0 && iw->font) {
+    SDL_Color white = {255, 255, 255, 255};
+    SDL_Rect pos = {text_x, 0, 0, 0};
+    int tw, th;
+    if (TTF_SizeUTF8(iw->font, iw->buf, &tw, &th) == 0)
+      pos.y = w->rect.y + (w->rect.h - th) / 2;
+    else
+      pos.y = w->rect.y + 4;
+
+    SDL_Surface *surf = TTF_RenderUTF8_Blended(iw->font, iw->buf, white);
+    if (surf) {
+      SDL_Texture *tex = SDL_CreateTextureFromSurface(r, surf);
+      if (tex) {
+        SDL_Rect dst = {pos.x, pos.y, surf->w, surf->h};
+        SDL_RenderCopy(r, tex, NULL, &dst);
+        SDL_DestroyTexture(tex);
+      }
+      SDL_FreeSurface(surf);
+    }
+  }
+
+  /* Blinking cursor when focused */
+  if (iw->focused) {
+    bool cursor_visible = (SDL_GetTicks() / CURSOR_BLINK_MS) % 2 == 0;
+    if (cursor_visible) {
+      int cursor_x = text_x;
+      if (iw->len > 0 && iw->font) {
+        int tw, th;
+        if (TTF_SizeUTF8(iw->font, iw->buf, &tw, &th) == 0)
+          cursor_x = text_x + tw + 1;
+      }
+      int cursor_top = w->rect.y + 4;
+      int cursor_bot = w->rect.y + w->rect.h - 4;
+      SDL_SetRenderDrawColor(r, 255, 255, 255, 255);
+      SDL_RenderDrawLine(r, cursor_x, cursor_top, cursor_x, cursor_bot);
+    }
+  }
+}
+
+static void input_widget_destroy(UIWidget_t *w) {
+  free(w);
+}
+
+InputWidget_t *input_widget_create(const char *initial, TTF_Font *font, int w, ConfigType type) {
+  InputWidget_t *iw = calloc(1, sizeof(*iw));
+  if (!iw)
+    return NULL;
+
+  iw->type = type;
+  iw->font = font;
+
+  if (initial && *initial) {
+    size_t n = strlen(initial);
+    if (n >= MAX_INPUT_LENGTH)
+      n = MAX_INPUT_LENGTH - 1;
+    memcpy(iw->buf, initial, n);
+    iw->buf[n] = '\0';
+    iw->len = n;
+  }
+
+  int th = 20;
+  if (font)
+    TTF_SizeUTF8(font, "Ag", NULL, &th);
+
+  iw->base.rect.w = w;
+  iw->base.rect.h = th + 16;
+  iw->base.render = input_widget_render;
+  iw->base.destroy = input_widget_destroy;
+
+  return iw;
+}
+
+bool input_widget_append(InputWidget_t *iw, const char *text) {
+  if (!iw || !text || !*text)
+    return false;
+
+  size_t add_len = strlen(text);
+  if (iw->len + add_len >= MAX_INPUT_LENGTH)
+    return false;
+
+  if (!chars_allowed(text, iw->type, iw->buf))
+    return false;
+
+  memcpy(iw->buf + iw->len, text, add_len);
+  iw->len += add_len;
+  iw->buf[iw->len] = '\0';
+  return true;
+}
+
+void input_widget_backspace(InputWidget_t *iw) {
+  if (!iw || iw->len == 0)
+    return;
+
+  /* Walk back one UTF-8 character (continuation bytes start with 10xxxxxx) */
+  do {
+    iw->len--;
+  } while (iw->len > 0 && ((unsigned char)iw->buf[iw->len] & 0xC0) == 0x80);
+
+  iw->buf[iw->len] = '\0';
+}
+
+const char *input_widget_get_text(const InputWidget_t *iw) {
+  return iw ? iw->buf : "";
+}

--- a/src/widgets/input.h
+++ b/src/widgets/input.h
@@ -1,0 +1,30 @@
+#ifndef __INPUT_WIDGET_H
+#define __INPUT_WIDGET_H
+
+#include "../dc_config.h"
+#include "ui_widget.h"
+
+typedef struct {
+  UIWidget_t base;
+
+  char buf[MAX_INPUT_LENGTH];
+  size_t len;
+  bool focused;
+  ConfigType type;
+  TTF_Font *font;
+} InputWidget_t;
+
+/* Create an input widget with an optional initial value, font, pixel width,
+ * and ConfigType used for character validation. */
+InputWidget_t *input_widget_create(const char *initial, TTF_Font *font, int w, ConfigType type);
+
+/* Append text (e.g. from SDL_TEXTINPUT). Returns true if any text was added. */
+bool input_widget_append(InputWidget_t *iw, const char *text);
+
+/* Remove the last UTF-8 character. */
+void input_widget_backspace(InputWidget_t *iw);
+
+/* Get the current buffer contents. */
+const char *input_widget_get_text(const InputWidget_t *iw);
+
+#endif

--- a/src/widgets/meson.build
+++ b/src/widgets/meson.build
@@ -2,6 +2,7 @@ widgets_src = files(
   'button.c',
   'dealer.c',
   'indicator.c',
+  'input.c',
   'nick.c',
   'ping.c',
   'text.c',


### PR DESCRIPTION
Adds a generic InputWidget_t (src/widgets/input.h/.c) that wraps a text input field with per-character validation driven by ConfigType. Numeric types (INT, UINT*) reject non-digit characters; BOOL only accepts y/n/t/f/1/0; STRING accepts all printable input. The widget draws a dark-background box with a highlighted border when focused and a blinking cursor.

Replaces the raw SDL text-input handling in menu_display_connect() with InputWidget_t, resolving the TODO at that site.