### PR TITLE
fix: correct do_socket_cleanup slot parameter type from bool to int

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1369,7 +1369,7 @@ static int recv_and_validate_protocol_header(TCPsocket sock) {
 }
 
 static void do_socket_cleanup(TCPsocket sock, SDLNet_SocketSet socket_set, bool *slot_taken,
-                              const bool slot, Player_t *p) {
+                              const int slot, Player_t *p) {
   SDLNet_TCP_DelSocket(socket_set, sock);
   SDLNet_TCP_Close(sock);
   slot_taken[slot] = false;


### PR DESCRIPTION
The slot parameter was declared as `const bool`, causing any slot index
of 2 or higher to be silently coerced to 1 when used as an array index
into slot_taken[].  This meant only slots 0 and 1 could ever be freed
by this function; higher slots would leak.