### PR TITLE
Move server password from --password CLI arg to server.conf / DC_PASS…

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,7 +3,7 @@
   + Add two animated card backs: lava lamp and sunset (#178)
   * bugfix: Client freezes (infinite loop in layout_cards) when slot-0
     player disconnects during a game (#195)
-  + Implement server authentication
+  + Server password set via server.conf or DC_PASSWORD env var (#187)
   + Add dealer indicator column to lobby player list (black square, red circle if dealer)
   + Highlight local player's nick with a semi-transparent background in the lobby
   + Admin can select other players in the lobby by clicking their nick

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ the [docker-compose
 file](https://github.com/Dealer-s-Choice/dealers_choice/tree/trunk/docker) or
 [tmux](https://coderwall.com/p/purqma/use-tmux-for-a-poor-man-s-daemon).
 
+See [docs/CONFIG.md](docs/CONFIG.md) for server configuration options including
+password protection.
+
 ## Client
 
 To run the client, simply run the binary without any arguments. A game can not

--- a/data/server.conf
+++ b/data/server.conf
@@ -11,3 +11,4 @@ max_raises = 3
 bet_minimum = 100
 bet_median = 250
 bet_maximum = 500
+password =

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,5 +1,34 @@
 # Config
 
+## Server Config
+
+The server reads
+[data/server.conf](https://github.com/Dealer-s-Choice/dealers_choice/blob/trunk/data/server.conf)
+on startup (or the file specified via `--server-conf`).
+
+### Password
+
+To require players to authenticate before joining, set a password:
+
+```
+password = mysecretpassword
+```
+
+Leave the value empty (or omit the key) to allow anyone to connect without a
+password.
+
+The `DC_PASSWORD` environment variable takes precedence over `server.conf`:
+
+```
+DC_PASSWORD=mysecretpassword ./dealers-choice --server
+```
+
+Clients must also have `DC_PASSWORD` set to the same value in order to connect.
+
+---
+
+## Player Config
+
 When you run the client from a terminal, you'll see the path to your config
 file. You can edit settings from the Settings menu on the startup screen, or
 by editing the file directly.

--- a/src/client.c
+++ b/src/client.c
@@ -1922,7 +1922,9 @@ bool get_socket_context_and_run_client(PlayerConfig_t *player_config,
   }
 
   if (!test_mode) {
-    const char *password = cli_args->password ? cli_args->password : "";
+    const char *password = getenv("DC_PASSWORD");
+    if (!password)
+      password = "";
     if (authenticate_with_server(sock, password) < 0)
       fprintf(stderr, "Authentication attempt failed\n");
 

--- a/src/dc_config.c
+++ b/src/dc_config.c
@@ -192,6 +192,12 @@ ServerConfig_t get_server_config(Path_t *path, const CliArgs_t *cli_args) {
 
     canfigger_free_current_key_node_advance(&cfg_node);
   }
+
+  // DC_PASSWORD env var takes precedence over server.conf
+  const char *env_pw = getenv("DC_PASSWORD");
+  if (env_pw)
+    snprintf(config.password, sizeof(config.password), "%s", env_pw);
+
   return config;
 }
 

--- a/src/dc_config.h
+++ b/src/dc_config.h
@@ -49,6 +49,7 @@ typedef struct ServerConfig_t {
   uint32_t bet_median;
   uint32_t bet_maximum;
   uint8_t action_timeout_max;
+  char password[256];
 } ServerConfig_t;
 
 typedef struct {
@@ -114,7 +115,9 @@ static const ConfigEntry server_config_entries[] = {
     {"bet_maximum", CFG_TYPE_UINT32, "500", offsetof(ServerConfig_t, bet_maximum),
      sizeof(uint32_t)},
     {"action_timeout_max", CFG_TYPE_UINT8, "3", offsetof(ServerConfig_t, action_timeout_max),
-     sizeof(uint8_t)}};
+     sizeof(uint8_t)},
+    {"password", CFG_TYPE_STRING, "", offsetof(ServerConfig_t, password),
+     sizeof(((ServerConfig_t *)0)->password)}};
 
 static const size_t server_config_entry_count = ARRAY_SIZE(server_config_entries);
 

--- a/src/main.c
+++ b/src/main.c
@@ -531,7 +531,6 @@ static CliArgs_t parse_cli_args(int argc, char *argv[]) {
     OPT_VERBOSE,
     OPT_DISABLE_AUDIO,
     OPT_DISABLE_TIMEOUT,
-    OPT_PASSWORD,
   };
 
   static const glopt_option_t options[] = {
@@ -546,7 +545,6 @@ static CliArgs_t parse_cli_args(int argc, char *argv[]) {
       {"verbose", GLOPT_NO_ARG, OPT_VERBOSE},
       {"disable-audio", GLOPT_NO_ARG, OPT_DISABLE_AUDIO},
       {"disable-timeout", GLOPT_NO_ARG, OPT_DISABLE_TIMEOUT},
-      {"password", GLOPT_REQUIRED_ARG, OPT_PASSWORD},
       {NULL, 0, 0}};
 
   glopt_parser_t parser;
@@ -595,9 +593,6 @@ static CliArgs_t parse_cli_args(int argc, char *argv[]) {
     case OPT_DISABLE_TIMEOUT:
       cli_args.disable_timeout = true;
       break;
-    case OPT_PASSWORD:
-      cli_args.password = parser.optarg;
-      break;
     case '?':
     default:
       print_version();
@@ -611,7 +606,6 @@ static CliArgs_t parse_cli_args(int argc, char *argv[]) {
             "  --disable-audio\n"
             "  --disable-timeout          Server will not disconnect players who exceed the action "
             "timeout threshold\n"
-            "  --password                 Not required\n"
             "  --version\n",
             stderr);
       exit(EXIT_FAILURE);

--- a/src/main.h
+++ b/src/main.h
@@ -36,7 +36,6 @@ typedef struct {
   bool test_mode, run_server_flag;
   bool disable_audio;
   bool disable_timeout;
-  const char *password;
 } CliArgs_t;
 
 #endif

--- a/src/server.c
+++ b/src/server.c
@@ -1483,15 +1483,12 @@ static ELoop_t register_new_client(ArgsBroadcastGameState_t *args) {
           return -1;
         }
 
-        const char *password = args->cli_args->password ? args->cli_args->password : "";
-        if (verify_client_password(new_client, password, nonce) < 0 || !args->cli_args->password) {
-          // fprintf(stderr, "Authentication failed, but not required\n");
-          player->is_admin = false;
+        const char *password = args->config->password;
+        if (*password && verify_client_password(new_client, password, nonce) >= 0) {
+          puts("Client authenticated!");
+          player->is_admin = true;
         } else {
-          if (args->cli_args->password) {
-            puts("Client authenticated!");
-            player->is_admin = true;
-          }
+          player->is_admin = false;
         }
 
         int16_t net_len;


### PR DESCRIPTION
…WORD env var (resolves #187)

- Add password field to ServerConfig_t, read from server.conf
- DC_PASSWORD env var takes precedence over server.conf (both server and client)
- Add password key to data/server.conf (empty by default)
- Document in docs/CONFIG.md and README.md
- Update ChangeLog