### PR TITLE
Fix connection screen: cancel button, per-attempt timeout, return to …

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -69,6 +69,12 @@ sound.volume = 7 # You can use a range of 0 - 10
 sound.notify.turn = yes # Use "no" to disable your turn audio notification
 ```
 
+## Connection
+
+```
+connect.attempts = 6 # Number of connection attempts before giving up
+```
+
 ## Language
 
 To use a language that is different from your system's default:

--- a/src/client.c
+++ b/src/client.c
@@ -52,7 +52,6 @@
 #include <sodium.h>
 #endif
 
-const uint8_t MAX_CONNECTION_ATTEMPTS = 12;
 static const uint8_t coin_px = 96;
 
 static const SDL_Rect card_area = {0, 0, 80, 50};
@@ -2186,6 +2185,19 @@ cleanup:
   return running;
 }
 
+typedef struct {
+  IPaddress server_ip;
+  TCPsocket sock;
+  SDL_atomic_t done;
+} ConnectAttempt_t;
+
+static int connect_thread_fn(void *data) {
+  ConnectAttempt_t *ca = data;
+  ca->sock = SDLNet_TCP_Open(&ca->server_ip);
+  SDL_AtomicSet(&ca->done, 1);
+  return 0;
+}
+
 int authenticate_with_server(TCPsocket sock, const char *password) {
   unsigned char nonce[NONCE_SIZE];
   unsigned char hash[HASH_SIZE];
@@ -2234,39 +2246,135 @@ bool get_socket_context_and_run_client(PlayerConfig_t *player_config,
     return false;
   }
 
+  // SDLNet_TCP_Open blocks for the OS TCP timeout on unreachable hosts.
+  // Run each attempt on a background thread; heap-allocate the state so we
+  // can safely SDL_DetachThread (rather than WaitThread) on cancel/timeout.
+  // Per-attempt timeout keeps the counter advancing on slow/unreachable hosts.
+  static const Uint32 ATTEMPT_TIMEOUT_MS = 5000;
+  static const Uint32 RETRY_DELAY_MS     = 2000;
+
+  Button_t btn_cancel = create_button(_("Cancel"), (EColor_t){COLOR_BLACK, COLOR_YELLOW},
+                                      font->fonts[FONT_BOLD], SDLK_ESCAPE);
+  btn_cancel.rect.x = g_center.x - btn_cancel.rect.w / 2;
+  btn_cancel.rect.y = g_center.y + 60;
+
+  TextWidget_t *status_tw = text_widget_create("", font->fonts[FONT_DEFAULT],
+                                               get_color(COLOR_WHITE));
+
+  bool cancelled = false;
+  bool sdl_quit  = false;
   uint8_t attempts;
-  for (attempts = 0; attempts < MAX_CONNECTION_ATTEMPTS; ++attempts) {
-    socket_context.sock = SDLNet_TCP_Open(&server_ip);
-    if (socket_context.sock) {
-      break; // Success
+  for (attempts = 0; attempts < player_config->connect_attempts; ++attempts) {
+    if (status_tw) {
+      char tmp[256] = {0};
+      snprintf(tmp, sizeof(tmp), _("Attempting connection to: %s... (%d/%d)"),
+               host_str, attempts + 1, player_config->connect_attempts);
+      text_widget_set_text(status_tw, tmp);
+      status_tw->base.rect.x = 10;
+      status_tw->base.rect.y = g_center.y;
     }
 
-    fprintf(stderr, "Attempt %d: Failed to connect to server: %s\n", attempts + 1,
-            SDLNet_GetError());
+    ConnectAttempt_t *ca = SDL_malloc(sizeof(ConnectAttempt_t));
+    if (!ca)
+      break;
+    ca->server_ip = server_ip;
+    ca->sock      = NULL;
+    SDL_AtomicSet(&ca->done, 0);
 
-    bool quit = false;
-    if (attempts < MAX_CONNECTION_ATTEMPTS - 1) {
-      Uint32 start = SDL_GetTicks();
-      while (SDL_GetTicks() - start < 5000) {
-        SDL_Event e;
-        while (SDL_PollEvent(&e)) {
-          if (e.type == SDL_QUIT)
-            quit = true;
+    SDL_Thread *thread = SDL_CreateThread(connect_thread_fn, "tcp_connect", ca);
+    if (!thread) {
+      // Fallback: blocking connect with no event handling this attempt
+      ca->sock = SDLNet_TCP_Open(&server_ip);
+      SDL_AtomicSet(&ca->done, 1);
+    }
+
+    Uint32 attempt_start = SDL_GetTicks();
+    bool timed_out = false;
+
+    while (!SDL_AtomicGet(&ca->done) && !cancelled && !sdl_quit) {
+      if (SDL_GetTicks() - attempt_start >= ATTEMPT_TIMEOUT_MS) {
+        timed_out = true;
+        break;
+      }
+      clear_screen(sdl_context->renderer);
+      if (status_tw)
+        status_tw->base.render(&status_tw->base);
+      render_button(&btn_cancel);
+      SDL_RenderPresent(sdl_context->renderer);
+      SDL_Event e;
+      while (SDL_PollEvent(&e)) {
+        SDL_Point mp = {e.button.x, e.button.y};
+        if (e.type == SDL_QUIT) {
+          sdl_quit = true;
+        } else if (e.type == SDL_KEYDOWN && e.key.keysym.sym == SDLK_ESCAPE) {
+          cancelled = true;
+        } else if (e.type == SDL_MOUSEBUTTONDOWN && e.button.button == SDL_BUTTON_LEFT) {
+          if (SDL_PointInRect(&mp, &btn_cancel.rect))
+            cancelled = true;
+        } else if (e.type == SDL_MOUSEMOTION) {
+          SDL_Point mmp = {e.motion.x, e.motion.y};
+          btn_cancel.hovered = SDL_PointInRect(&mmp, &btn_cancel.rect);
         }
-        SDL_Delay(16);
-        if (quit)
-          break;
+      }
+      SDL_Delay(16);
+    }
+
+    if (thread && !SDL_AtomicGet(&ca->done)) {
+      // Thread is still running (cancelled or timed out). Detach it and leave
+      // ca allocated — the thread will write to it and exit on its own.
+      SDL_DetachThread(thread);
+      thread = NULL;
+    } else {
+      // Thread finished normally; safe to wait and free.
+      if (thread)
+        SDL_WaitThread(thread, NULL);
+      TCPsocket s = ca->sock;
+      SDL_free(ca);
+      ca = NULL;
+      if (s) {
+        socket_context.sock = s;
+        break;
       }
     }
-    if (quit) {
-      attempts++;
+
+    if (cancelled || sdl_quit)
       break;
+
+    if (!timed_out)
+      fprintf(stderr, "Attempt %d: Failed to connect to server: %s\n", attempts + 1,
+              SDLNet_GetError());
+
+    // Brief pause between retries (skip if this was the last attempt)
+    if (attempts < (uint8_t)(player_config->connect_attempts - 1)) {
+      Uint32 start = SDL_GetTicks();
+      while (SDL_GetTicks() - start < RETRY_DELAY_MS && !cancelled && !sdl_quit) {
+        SDL_Event e;
+        while (SDL_PollEvent(&e)) {
+          SDL_Point mp = {e.button.x, e.button.y};
+          if (e.type == SDL_QUIT) {
+            sdl_quit = true;
+          } else if (e.type == SDL_KEYDOWN && e.key.keysym.sym == SDLK_ESCAPE) {
+            cancelled = true;
+          } else if (e.type == SDL_MOUSEBUTTONDOWN && e.button.button == SDL_BUTTON_LEFT) {
+            if (SDL_PointInRect(&mp, &btn_cancel.rect))
+              cancelled = true;
+          } else if (e.type == SDL_MOUSEMOTION) {
+            SDL_Point mmp = {e.motion.x, e.motion.y};
+            btn_cancel.hovered = SDL_PointInRect(&mmp, &btn_cancel.rect);
+          }
+        }
+        SDL_Delay(16);
+      }
     }
   }
 
+  if (status_tw)
+    ui_widget_destroy(&status_tw->base);
+
   if (!socket_context.sock) {
-    printf("All %d attempts failed. Giving up.\n", attempts);
-    return false;
+    if (!cancelled && !sdl_quit)
+      printf("All %d attempts failed.\n", attempts);
+    return !sdl_quit;
   }
 
   TCPsocket sock = socket_context.sock;

--- a/src/client.c
+++ b/src/client.c
@@ -2253,13 +2253,15 @@ bool get_socket_context_and_run_client(PlayerConfig_t *player_config,
   static const Uint32 ATTEMPT_TIMEOUT_MS = 5000;
   static const Uint32 RETRY_DELAY_MS     = 2000;
 
-  Button_t btn_cancel = create_button(_("Cancel"), (EColor_t){COLOR_BLACK, COLOR_YELLOW},
-                                      font->fonts[FONT_BOLD], SDLK_ESCAPE);
-  btn_cancel.rect.x = g_center.x - btn_cancel.rect.w / 2;
-  btn_cancel.rect.y = g_center.y + 60;
-
-  TextWidget_t *status_tw = text_widget_create("", font->fonts[FONT_DEFAULT],
-                                               get_color(COLOR_WHITE));
+  Button_t btn_cancel = {0};
+  TextWidget_t *status_tw = NULL;
+  if (sdl_context && font) {
+    btn_cancel = create_button(_("Cancel"), (EColor_t){COLOR_BLACK, COLOR_YELLOW},
+                               font->fonts[FONT_BOLD], SDLK_ESCAPE);
+    btn_cancel.rect.x = g_center.x - btn_cancel.rect.w / 2;
+    btn_cancel.rect.y = g_center.y + 60;
+    status_tw = text_widget_create("", font->fonts[FONT_DEFAULT], get_color(COLOR_WHITE));
+  }
 
   bool cancelled = false;
   bool sdl_quit  = false;
@@ -2296,11 +2298,14 @@ bool get_socket_context_and_run_client(PlayerConfig_t *player_config,
         timed_out = true;
         break;
       }
-      clear_screen(sdl_context->renderer);
-      if (status_tw)
-        status_tw->base.render(&status_tw->base);
-      render_button(&btn_cancel);
-      SDL_RenderPresent(sdl_context->renderer);
+      if (sdl_context) {
+        clear_screen(sdl_context->renderer);
+        if (status_tw)
+          status_tw->base.render(&status_tw->base);
+        if (btn_cancel.active)
+          render_button(&btn_cancel);
+        SDL_RenderPresent(sdl_context->renderer);
+      }
       SDL_Event e;
       while (SDL_PollEvent(&e)) {
         SDL_Point mp = {e.button.x, e.button.y};

--- a/src/client.c
+++ b/src/client.c
@@ -2260,14 +2260,21 @@ bool get_socket_context_and_run_client(PlayerConfig_t *player_config,
                                font->fonts[FONT_BOLD], SDLK_ESCAPE);
     btn_cancel.rect.x = g_center.x - btn_cancel.rect.w / 2;
     btn_cancel.rect.y = g_center.y + 60;
-    status_tw = text_widget_create("", font->fonts[FONT_DEFAULT], get_color(COLOR_WHITE));
+    char initial_status[256] = {0};
+    snprintf(initial_status, sizeof(initial_status), _("Attempting connection to: %s... (%d/%d)"),
+             host_str, 1, player_config->connect_attempts);
+    status_tw = text_widget_create(initial_status, font->fonts[FONT_DEFAULT], get_color(COLOR_WHITE));
+    if (status_tw) {
+      status_tw->base.rect.x = 10;
+      status_tw->base.rect.y = g_center.y;
+    }
   }
 
   bool cancelled = false;
   bool sdl_quit  = false;
   uint8_t attempts;
   for (attempts = 0; attempts < player_config->connect_attempts; ++attempts) {
-    if (status_tw) {
+    if (status_tw && attempts > 0) {
       char tmp[256] = {0};
       snprintf(tmp, sizeof(tmp), _("Attempting connection to: %s... (%d/%d)"),
                host_str, attempts + 1, player_config->connect_attempts);

--- a/src/dc_config.h
+++ b/src/dc_config.h
@@ -59,6 +59,7 @@ typedef struct {
   char language[6];
   int volume;
   bool turn_notify;
+  uint8_t connect_attempts;
 } PlayerConfig_t;
 
 typedef enum {
@@ -88,7 +89,9 @@ static const ConfigEntry player_config_entries[] = {
      sizeof(((PlayerConfig_t *)0)->language)},
     {"sound.volume", CFG_TYPE_INT, "5", offsetof(PlayerConfig_t, volume), sizeof(int)},
     {"sound.notify.turn", CFG_TYPE_BOOL, "yes", offsetof(PlayerConfig_t, turn_notify),
-     sizeof(bool)}};
+     sizeof(bool)},
+    {"connect.attempts", CFG_TYPE_UINT8, "6", offsetof(PlayerConfig_t, connect_attempts),
+     sizeof(uint8_t)}};
 
 static const size_t player_config_entry_count = ARRAY_SIZE(player_config_entries);
 

--- a/src/main.c
+++ b/src/main.c
@@ -259,7 +259,7 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
   /* Two-column layout for nick, language, volume, turn_notify (host/port on startup screen) */
   const int x_left = g_viewport.x + 100;
   const int x_right = g_viewport.x + 700;
-  const int row_y[2] = {g_viewport.y + 160, g_viewport.y + 360};
+  const int row_y[3] = {g_viewport.y + 160, g_viewport.y + 360, g_viewport.y + 560};
   const int input_y_offset = 40;
   const int input_w = 350;
 
@@ -320,6 +320,9 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
       break;
     case CFG_TYPE_INT:
       snprintf(init_str[i], sizeof(init_str[i]), "%d", *(const int *)field);
+      break;
+    case CFG_TYPE_UINT8:
+      snprintf(init_str[i], sizeof(init_str[i]), "%u", (unsigned)*(const uint8_t *)field);
       break;
     case CFG_TYPE_UINT16:
       snprintf(init_str[i], sizeof(init_str[i]), "%u", (unsigned)*(const uint16_t *)field);
@@ -763,12 +766,6 @@ int main(int argc, char *argv[]) {
     } while (connect_result == RUN_SETTINGS);
 
     if (connect_result == RUN_CLIENT) {
-      char tmp[256] = {0};
-      snprintf(tmp, sizeof(tmp), _("Attempting connection to: %s..."), host_str);
-      render_text_plain(sdl_context.renderer, font.fonts[FONT_DEFAULT], tmp, get_color(COLOR_WHITE),
-                        &(SDL_Rect){10, g_center.y, 0, 0});
-      SDL_RenderPresent(sdl_context.renderer);
-
       bool went_back = get_socket_context_and_run_client(&player_config, &cli_args, host_str, port,
                                                          &sdl_context, &font, &path,
                                                          cli_args.test_mode, links, NULL);


### PR DESCRIPTION
…menu

- Add Cancel button (and Escape hotkey) to abort an in-progress connection
- Run SDLNet_TCP_Open on a background thread so the main thread stays responsive; SDL_DetachThread on cancel/timeout avoids blocking the UI
- Add a 5-second per-attempt timeout so the counter advances on unreachable hosts instead of stalling indefinitely
- Return to the connect menu on all failure paths (exhausted retries, timeout, cancel); only SDL_QUIT exits the client
- Add connect.attempts (default 6) to player config; fixes settings screen crash caused by row_y array too small for the new entry
- Use TextWidget_t for the status message instead of render_text_plain
- Closes #204