### PR TITLE
Fix Windows path handling and install configuration

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,14 @@
 
 - dealers-choice (in progress):
   + Add Texas Hold'em
-  + Add two animated card backs: lava lamp and sunset (#178)
   * bugfix: Client freezes (infinite loop in layout_cards) when slot-0
+  + Connection screen: cancel button, per-attempt timeout, configurable
+    retry count (connect.attempts in player config), return to menu on
+    failure (#204)
+  * bugfix: Windows path handling — shell32 now linked for
+    SHGetFolderPathA; check_pathname_state verifies FILE_ATTRIBUTE_DIRECTORY
+  * bugfix: .desktop and XDG icon installs skipped on Windows
+  + Add animated card backs
     player disconnects during a game (#195)
   + Server password set via server.conf or DC_PASSWORD env var (#187)
   + Add dealer indicator column to lobby player list (black square, red circle if dealer)

--- a/meson.build
+++ b/meson.build
@@ -24,7 +24,7 @@ platform_is_windows = (host_sys == 'windows')
 
 win_deps = []
 if platform_is_windows
-  w_lib = ['ws2_32', 'user32']
+  w_lib = ['ws2_32', 'user32', 'shell32']
   foreach lib : w_lib
     win_deps += cc.find_library(lib, required: true)
   endforeach
@@ -187,37 +187,39 @@ install_subdir('docs', install_dir: get_option('docdir'))
 
 #install_data(files('LICENSE'), install_dir: license_dir)
 
-install_data(
-  'packaging/dealers-choice.desktop',
-  install_dir: join_paths(get_option('datadir'), 'applications'),
-)
-
-icon_sizes = ['128', '64', '32', '16']
-
-foreach size : icon_sizes
+if not platform_is_windows
   install_data(
-    'packaging/icons/dealers-choice_@0@x@0@.png'.format(size),
-    rename: 'dealers-choice.png',
+    'packaging/dealers-choice.desktop',
+    install_dir: join_paths(get_option('datadir'), 'applications'),
+  )
+
+  icon_sizes = ['128', '64', '32', '16']
+
+  foreach size : icon_sizes
+    install_data(
+      'packaging/icons/dealers-choice_@0@x@0@.png'.format(size),
+      rename: 'dealers-choice.png',
+      install_dir: join_paths(
+        get_option('datadir'),
+        'icons',
+        'hicolor',
+        '@0@x@0@'.format(size),
+        'apps',
+      ),
+    )
+  endforeach
+
+  install_data(
+    'packaging/icons/dealers-choice.svg',
     install_dir: join_paths(
       get_option('datadir'),
       'icons',
       'hicolor',
-      '@0@x@0@'.format(size),
+      'scalable',
       'apps',
     ),
   )
-endforeach
-
-install_data(
-  'packaging/icons/dealers-choice.svg',
-  install_dir: join_paths(
-    get_option('datadir'),
-    'icons',
-    'hicolor',
-    'scalable',
-    'apps',
-  ),
-)
+endif
 
 # Third-party licenses
 install_subdir('licenses', install_dir: get_option('docdir'))

--- a/src/util.c
+++ b/src/util.c
@@ -133,7 +133,7 @@ EPathState check_pathname_state(const char *pathname) {
     return (GetLastError() == ERROR_FILE_NOT_FOUND || GetLastError() == ERROR_PATH_NOT_FOUND)
                ? PATH_NOT_FOUND
                : PATH_ERROR;
-  return PATH_EXISTS;
+  return (attrs & FILE_ATTRIBUTE_DIRECTORY) ? PATH_EXISTS : PATH_ERROR;
 #else
   struct stat sb;
   if (stat(pathname, &sb) == 0 && S_ISDIR(sb.st_mode))
@@ -281,8 +281,8 @@ char *real_join_paths(long path_max, const char *first, ...) {
     }
 
     // Add separator if needed
-    if (len > 0 && path[len - 1] != '/' && segment[0] != '/') {
-      path[len++] = '/';
+    if (len > 0 && path[len - 1] != PATH_SEP && segment[0] != PATH_SEP) {
+      path[len++] = PATH_SEP;
     }
 
     strcpy(path + len, segment);


### PR DESCRIPTION

- Add shell32 to win_deps (required for SHGetFolderPathA)
- check_pathname_state: check FILE_ATTRIBUTE_DIRECTORY on Windows so a
  file named 'data' doesn't pass as a valid data directory
- real_join_paths: use PATH_SEP instead of hardcoded '/'
- Guard .desktop and XDG icon installs behind !platform_is_windows