### PR TITLE
ci: fix PKG_CONFIG path for MSVC build — pkgconf installs to x64-wind…

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -1,0 +1,70 @@
+name: MSVC
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [ trunk ]
+    paths: &shared_paths
+    - '**'
+    - '!**.yml'
+    - '!**.md'
+    - '**/msvc.yml'
+
+  pull_request:
+    branches: [ trunk ]
+    paths: *shared_paths
+
+jobs:
+  msvc:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Restore vcpkg cache
+      uses: actions/cache/restore@v4
+      with:
+        path: C:\vcpkg\installed\x64-windows-static-md
+        key: vcpkg-installed-x64-windows-static-md-${{ hashFiles('.github/workflows/msvc.yml') }}
+        restore-keys: vcpkg-installed-x64-windows-static-md-
+
+    - name: Set up MSVC environment
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: x64
+
+    - name: Install Meson and Ninja
+      run: pip install meson ninja
+
+    - name: Install dependencies via vcpkg
+      run: |
+        $env:VCPKG_ROOT = ""
+        vcpkg install `
+          --overlay-triplets=vcpkg-triplets `
+          sdl2:x64-windows-static-md `
+          sdl2-image:x64-windows-static-md `
+          sdl2-ttf:x64-windows-static-md `
+          sdl2-net:x64-windows-static-md `
+          libsodium:x64-windows-static-md `
+          protobuf-c:x64-windows-static-md
+
+    - name: Save vcpkg cache
+      uses: actions/cache/save@v4
+      if: always()
+      with:
+        path: C:\vcpkg\installed\x64-windows-static-md
+        key: vcpkg-installed-x64-windows-static-md-${{ hashFiles('.github/workflows/msvc.yml') }}
+
+    - name: Meson setup
+      run: |
+        $vcpkg_prefix = "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows-static-md"
+        $env:PKG_CONFIG = "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\tools\pkgconf\pkgconf.exe"
+        $env:PKG_CONFIG_PATH = "$vcpkg_prefix\lib\pkgconfig"
+        meson setup _build -Db_sanitize=none -Dsodium=enabled "-Dcmake_prefix_path=$vcpkg_prefix"
+
+    - name: Build
+      run: meson compile -C _build
+
+    - name: Test
+      run: meson test --no-stdsplit -v -C _build

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -1,4 +1,4 @@
-name: Windows
+name: MSYS2
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -16,67 +16,14 @@ on:
     - '**'
     - '!**.yml'
     - '!**.md'
-    - '**/windows.yml'
+    - '**/msys.yml'
 
   pull_request:
     branches: [ trunk ]
     paths: *shared_paths
 
 jobs:
-  msvc:
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v6
-
-    - name: Restore vcpkg cache
-      uses: actions/cache/restore@v4
-      with:
-        path: C:\vcpkg\installed\x64-windows-static-md
-        key: vcpkg-installed-x64-windows-static-md-${{ hashFiles('.github/workflows/windows.yml') }}
-        restore-keys: vcpkg-installed-x64-windows-static-md-
-
-    - name: Set up MSVC environment
-      uses: ilammy/msvc-dev-cmd@v1
-      with:
-        arch: x64
-
-    - name: Install Meson and Ninja
-      run: pip install meson ninja
-
-    - name: Install dependencies via vcpkg
-      run: |
-        $env:VCPKG_ROOT = ""
-        vcpkg install `
-          --overlay-triplets=vcpkg-triplets `
-          sdl2:x64-windows-static-md `
-          sdl2-image:x64-windows-static-md `
-          sdl2-ttf:x64-windows-static-md `
-          sdl2-net:x64-windows-static-md `
-          libsodium:x64-windows-static-md `
-          protobuf-c:x64-windows-static-md
-
-    - name: Save vcpkg cache
-      uses: actions/cache/save@v4
-      if: always()
-      with:
-        path: C:\vcpkg\installed\x64-windows-static-md
-        key: vcpkg-installed-x64-windows-static-md-${{ hashFiles('.github/workflows/windows.yml') }}
-
-    - name: Meson setup
-      run: |
-        $vcpkg_prefix = "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows-static-md"
-        $env:PKG_CONFIG = "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\tools\pkgconf\pkgconf.exe"
-        $env:PKG_CONFIG_PATH = "$vcpkg_prefix\lib\pkgconfig"
-        meson setup _build -Db_sanitize=none -Dsodium=enabled "-Dcmake_prefix_path=$vcpkg_prefix"
-
-    - name: Build
-      run: meson compile -C _build
-
-    - name: Test
-      run: meson test --no-stdsplit -v -C _build
-
   MSYS2:
-    needs: msvc
     runs-on: windows-latest
     permissions:
       contents: write

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -16,7 +16,7 @@ on:
     - '**'
     - '!**.yml'
     - '!**.md'
-    - '**/msys.yml'
+    - '**/msys2.yml'
 
   pull_request:
     branches: [ trunk ]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,9 +31,9 @@ jobs:
     - name: Restore vcpkg cache
       uses: actions/cache/restore@v4
       with:
-        path: C:\Users\runneradmin\AppData\Local\vcpkg\archives
-        key: vcpkg-x64-windows-static-md-${{ hashFiles('.github/workflows/windows.yml') }}
-        restore-keys: vcpkg-x64-windows-static-md-
+        path: C:\vcpkg\installed\x64-windows-static-md
+        key: vcpkg-installed-x64-windows-static-md-${{ hashFiles('.github/workflows/windows.yml') }}
+        restore-keys: vcpkg-installed-x64-windows-static-md-
 
     - name: Set up MSVC environment
       uses: ilammy/msvc-dev-cmd@v1
@@ -59,8 +59,8 @@ jobs:
       uses: actions/cache/save@v4
       if: always()
       with:
-        path: C:\Users\runneradmin\AppData\Local\vcpkg\archives
-        key: vcpkg-x64-windows-static-md-${{ hashFiles('.github/workflows/windows.yml') }}
+        path: C:\vcpkg\installed\x64-windows-static-md
+        key: vcpkg-installed-x64-windows-static-md-${{ hashFiles('.github/workflows/windows.yml') }}
 
     - name: Meson setup
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Meson setup
       run: |
         $vcpkg_prefix = "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows-static-md"
-        $env:PKG_CONFIG = "$vcpkg_prefix\tools\pkgconf\pkgconf.exe"
+        $env:PKG_CONFIG = "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\tools\pkgconf\pkgconf.exe"
         $env:PKG_CONFIG_PATH = "$vcpkg_prefix\lib\pkgconfig"
         meson setup _build -Db_sanitize=none -Dsodium=enabled "-Dcmake_prefix_path=$vcpkg_prefix"
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@
   * Update docker-compose.yml to use DC_PASSWORD and extra arguments when running
     the server
   * Bump GAME_PROTOCOL_VERSION from 7 to 8
+  * Fix MSVC build
 
 2026-04-01
 

--- a/meson.build
+++ b/meson.build
@@ -111,9 +111,13 @@ dep_names = [
   'libprotobuf-c',
   'SDL2',
   'SDL2_ttf',
-  'SDL2_net',
   'SDL2_image',
 ]
+
+# SDL2_net ships as SDL2_net::SDL2_net-static in vcpkg static builds; specify
+# the CMake target explicitly so Meson doesn't fall back to the imprecise
+# SDL2_net_LIBRARIES variable when pkgconfig is unavailable (e.g. MSVC+vcpkg).
+shared_dep += dependency('SDL2_net', modules: ['SDL2_net::SDL2_net-static'])
 
 # On Slackware, the miniaudio build fails (linking) if dl and threads aren't added here
 # On FreeBSD, threads is needed.

--- a/meson.build
+++ b/meson.build
@@ -24,7 +24,10 @@ platform_is_windows = (host_sys == 'windows')
 
 win_deps = []
 if platform_is_windows
-  w_lib = ['ws2_32', 'user32', 'shell32']
+  # iphlpapi is required by SDL2_net-static (GetAdaptersInfo); Meson does not
+  # yet handle the $<LINK_ONLY:iphlpapi> CMake generator expression so we add
+  # it explicitly here.
+  w_lib = ['ws2_32', 'user32', 'shell32', 'iphlpapi']
   foreach lib : w_lib
     win_deps += cc.find_library(lib, required: true)
   endforeach


### PR DESCRIPTION
…ows triplet

vcpkg installs pkgconf as a host tool under the x64-windows triplet, not x64-windows-static-md, so the binary lives at:
  installed\x64-windows\tools\pkgconf\pkgconf.exe