### PR TITLE
stud: implement bring-in forced partial bet

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 
 - dealers-choice (in progress):
+  + Stud games: implement bring-in forced partial bet (bringin_amount in
+    server.conf, default 50); subsequent streets open with the player
+    holding the best visible hand
   + Deuces wild: server now evaluates wild hands automatically using
     POKEVAL_compare_hands_wild / POKEVAL_evaluate_hand_wild; removed the
     end-of-hand UI selection for wild card replacement and the associated

--- a/data/server.conf
+++ b/data/server.conf
@@ -5,6 +5,7 @@ action_timeout_ms = 30000
 action_timeout_max = 3
 dealer_timeout_ms = 30000
 ante = 50
+bringin_amount = 50
 starting_coins = 20000
 max_raises = 3
 bet_amounts = list, 100, 250, 500

--- a/docs/GAME_PLAY.md
+++ b/docs/GAME_PLAY.md
@@ -27,14 +27,14 @@ to disable; see `action_timeout_max` in server.conf).
 
 ## Hotkeys
 
-| Key | Action               |
-|-----|----------------------|
-| c   | call/check           |
-| r   | raise                |
-| f   | fold                 |
-| d   | discard              |
-| b   | bet                  |
-| x   | exchange (wild cards)|
+| Key | Action                  |
+|-----|-------------------------|
+| c   | call/check              |
+| r   | raise/complete          |
+| f   | fold                    |
+| d   | discard                 |
+| b   | bet                     |
+| x   | exchange (wild cards)   |
 
 
 The bet amount hotkeys correspond to the amounts configured in `bet_amounts`
@@ -55,23 +55,39 @@ Hotkeys are not implemented for everything yet, but they are planned, as well
 as [making them
 configurable](https://github.com/Dealer-s-Choice/dealers-choice/issues/102).
 
+## Stud Games (5-card, 6-card, 7-card stud)
+
+### Bring-in bet
+
+After the initial cards are dealt, the player with the **lowest face-up card** is required
+to post a forced partial bet called the **bring-in**.
+
+- Face value is compared ace-high (ace is highest, so twos bring in most often).
+- Ties are broken by suit rank: **clubs < diamonds < hearts < spades** (clubs brings in first).
+- The bring-in amount is set by `bringin_amount` in `server.conf` (default: 50).
+
+After the bring-in is placed, the action moves clockwise. Players may:
+
+- **Call** the bring-in amount
+- **Complete** (raise to the full small bet) or raise further, subject to the normal raise limit
+- **Fold**
+
+The bring-in player acts last. If no one has completed or raised, they may **Complete** for free
+(no additional cost beyond the bring-in already posted) or **Check**. The button is labeled
+"Complete" rather than "Raise" or "Bet" to make this distinction clear.
+
+### Subsequent streets
+
+On each street after the first, the player with the **best visible hand** acts first. They
+may check or bet freely — there is no forced bring-in on later streets.
+
 ### Using Wild Cards
 
-Selecting Deuces Wild will temporarily disable the following games until is is
+Selecting Deuces Wild will temporarily disable the following games until it is
 unselected:
 
-* Texas Hold'em
+* Texas Hold’em
 * California Lowball
 
-Only 2s can be wild, and only if the dealer has enabled wild cards.
-
-At the end of the final betting round, if you have a 2 in your hand, you’ll
-see an **"Exchange"** button and a column showing face values and suits.
-
-1. Click on a 2 in your hand.
-2. Click on a face value, a suit, or both in the column to assign that identity to your wild card.
-3. Repeat for any other 2 in your hand.
-4. When finished, click **"Exchange"** again to submit your changes.
-   *(Note: The button text may vary if a translation is enabled.)*
-
-[![Exchanging Wild Cards](https://dealer-s-choice.github.io/screenshots/dealers-choice_changing-wilds-2025-07-19.gif)](https://dealer-s-choice.github.io/screenshots/dealers-choice_changing-wilds-2025-07-19.gif)
+Only 2s can be wild, and only if the dealer has enabled wild cards. The server
+evaluates wild hands automatically at showdown.

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dealers-choice\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-31 23:08-0500\n"
+"POT-Creation-Date: 2026-04-08 16:31-0500\n"
 "PO-Revision-Date: 2025-06-19 21:52-0500\n"
 "Last-Translator: Andy <andy@prometheus.localhost.localdomain>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -41,56 +41,52 @@ msgstr ""
 msgid "Waiting for dealer to select game..."
 msgstr ""
 
-#: src/client.c:188 src/client.c:1662
+#: src/client.c:188 src/client.c:1608
 msgid "Kick"
 msgstr ""
 
-#: src/client.c:190 src/client.c:1664
+#: src/client.c:190 src/client.c:1610
 msgid "Ban"
 msgstr ""
 
 #. Show dealing screen immediately after click
-#: src/client.c:519
+#: src/client.c:521
 msgid "Dealing..."
 msgstr ""
 
-#: src/client.c:1252
+#: src/client.c:1239
 msgid "Check"
 msgstr "Prüfen"
 
-#: src/client.c:1252
+#: src/client.c:1239
 msgid "Bet"
 msgstr "Setzen"
 
-#: src/client.c:1253
+#: src/client.c:1240
 msgid "Fold"
 msgstr "Aufgeben"
 
-#: src/client.c:1253
+#: src/client.c:1240
 msgid "Call"
 msgstr "Mitgehen"
 
-#: src/client.c:1254
+#: src/client.c:1241
 msgid "Raise"
 msgstr "Erhöhen"
 
-#: src/client.c:1254
+#: src/client.c:1241
+msgid "Complete"
+msgstr ""
+
+#: src/client.c:1242
 msgid "Discard"
 msgstr "Ablegen"
 
-#: src/client.c:1255
-msgid "Exchange"
-msgstr ""
-
-#: src/client.c:1607
-msgid "Click a 2, then choose value and suit to assign."
-msgstr ""
-
-#: src/client.c:2467
+#: src/client.c:2369
 msgid "Cancel"
 msgstr ""
 
-#: src/client.c:2474 src/client.c:2490
+#: src/client.c:2376 src/client.c:2392
 #, c-format
 msgid "Attempting connection to: %s... (%d/%d)"
 msgstr ""
@@ -122,51 +118,60 @@ msgstr " Discord Channel (on Lazarus Project Server) "
 msgid "Website"
 msgstr ""
 
-#: src/server.c:92
+#: src/server.c:93
 #, c-format
 msgid ""
 "Warning: password is set but this build lacks libsodium; authentication is "
 "disabled and the password will be ignored.\n"
 msgstr ""
 
-#: src/server.c:678
+#: src/server.c:612
 #, fuzzy
 msgid "checked"
 msgstr "Prüfen"
 
-#: src/server.c:692
+#: src/server.c:626
 msgid "folded"
 msgstr "Hat aufgegeben"
 
-#: src/server.c:883
+#: src/server.c:817 src/server.c:839
+msgid "completed "
+msgstr ""
+
+#: src/server.c:817
 msgid "bet "
 msgstr ""
 
-#: src/server.c:897
+#: src/server.c:831
 msgid "called"
 msgstr ""
 
-#: src/server.c:903
+#: src/server.c:848
 #, fuzzy
 msgid "raised "
 msgstr "Erhöhen"
 
-#: src/server.c:1030
+#: src/server.c:975
 #, c-format
 msgid "%s disconnected"
 msgstr ""
 
-#: src/server.c:1046
+#: src/server.c:991
 #, c-format
 msgid "%s was kicked"
 msgstr ""
 
-#: src/server.c:1063
+#: src/server.c:1008
 #, c-format
 msgid "%s was banned"
 msgstr ""
 
-#: src/server.c:1374
+#: src/server.c:1245
+#, c-format
+msgid "%s brings in for %u"
+msgstr ""
+
+#: src/server.c:1411
 #, c-format
 msgid "Game: %s%s"
 msgstr ""

--- a/po/dealers-choice.pot
+++ b/po/dealers-choice.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dealers-choice\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-31 23:08-0500\n"
+"POT-Creation-Date: 2026-04-08 16:31-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -41,56 +41,52 @@ msgstr ""
 msgid "Waiting for dealer to select game..."
 msgstr ""
 
-#: src/client.c:188 src/client.c:1662
+#: src/client.c:188 src/client.c:1608
 msgid "Kick"
 msgstr ""
 
-#: src/client.c:190 src/client.c:1664
+#: src/client.c:190 src/client.c:1610
 msgid "Ban"
 msgstr ""
 
 #. Show dealing screen immediately after click
-#: src/client.c:519
+#: src/client.c:521
 msgid "Dealing..."
 msgstr ""
 
-#: src/client.c:1252
+#: src/client.c:1239
 msgid "Check"
 msgstr ""
 
-#: src/client.c:1252
+#: src/client.c:1239
 msgid "Bet"
 msgstr ""
 
-#: src/client.c:1253
+#: src/client.c:1240
 msgid "Fold"
 msgstr ""
 
-#: src/client.c:1253
+#: src/client.c:1240
 msgid "Call"
 msgstr ""
 
-#: src/client.c:1254
+#: src/client.c:1241
 msgid "Raise"
 msgstr ""
 
-#: src/client.c:1254
+#: src/client.c:1241
+msgid "Complete"
+msgstr ""
+
+#: src/client.c:1242
 msgid "Discard"
 msgstr ""
 
-#: src/client.c:1255
-msgid "Exchange"
-msgstr ""
-
-#: src/client.c:1607
-msgid "Click a 2, then choose value and suit to assign."
-msgstr ""
-
-#: src/client.c:2467
+#: src/client.c:2369
 msgid "Cancel"
 msgstr ""
 
-#: src/client.c:2474 src/client.c:2490
+#: src/client.c:2376 src/client.c:2392
 #, c-format
 msgid "Attempting connection to: %s... (%d/%d)"
 msgstr ""
@@ -121,49 +117,58 @@ msgstr ""
 msgid "Website"
 msgstr ""
 
-#: src/server.c:92
+#: src/server.c:93
 #, c-format
 msgid ""
 "Warning: password is set but this build lacks libsodium; authentication is "
 "disabled and the password will be ignored.\n"
 msgstr ""
 
-#: src/server.c:678
+#: src/server.c:612
 msgid "checked"
 msgstr ""
 
-#: src/server.c:692
+#: src/server.c:626
 msgid "folded"
 msgstr ""
 
-#: src/server.c:883
+#: src/server.c:817 src/server.c:839
+msgid "completed "
+msgstr ""
+
+#: src/server.c:817
 msgid "bet "
 msgstr ""
 
-#: src/server.c:897
+#: src/server.c:831
 msgid "called"
 msgstr ""
 
-#: src/server.c:903
+#: src/server.c:848
 msgid "raised "
 msgstr ""
 
-#: src/server.c:1030
+#: src/server.c:975
 #, c-format
 msgid "%s disconnected"
 msgstr ""
 
-#: src/server.c:1046
+#: src/server.c:991
 #, c-format
 msgid "%s was kicked"
 msgstr ""
 
-#: src/server.c:1063
+#: src/server.c:1008
 #, c-format
 msgid "%s was banned"
 msgstr ""
 
-#: src/server.c:1374
+#: src/server.c:1245
+#, c-format
+msgid "%s brings in for %u"
+msgstr ""
+
+#: src/server.c:1411
 #, c-format
 msgid "Game: %s%s"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dealers-choice\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-31 23:08-0500\n"
+"POT-Creation-Date: 2026-04-08 16:31-0500\n"
 "PO-Revision-Date: 2025-07-02 00:18-0500\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -41,56 +41,52 @@ msgstr ""
 msgid "Waiting for dealer to select game..."
 msgstr ""
 
-#: src/client.c:188 src/client.c:1662
+#: src/client.c:188 src/client.c:1608
 msgid "Kick"
 msgstr ""
 
-#: src/client.c:190 src/client.c:1664
+#: src/client.c:190 src/client.c:1610
 msgid "Ban"
 msgstr ""
 
 #. Show dealing screen immediately after click
-#: src/client.c:519
+#: src/client.c:521
 msgid "Dealing..."
 msgstr ""
 
-#: src/client.c:1252
+#: src/client.c:1239
 msgid "Check"
 msgstr "Pasar"
 
-#: src/client.c:1252
+#: src/client.c:1239
 msgid "Bet"
 msgstr "Apostar"
 
-#: src/client.c:1253
+#: src/client.c:1240
 msgid "Fold"
 msgstr "Retirarse"
 
-#: src/client.c:1253
+#: src/client.c:1240
 msgid "Call"
 msgstr "Igualar"
 
-#: src/client.c:1254
+#: src/client.c:1241
 msgid "Raise"
 msgstr "Subir"
 
-#: src/client.c:1254
+#: src/client.c:1241
+msgid "Complete"
+msgstr ""
+
+#: src/client.c:1242
 msgid "Discard"
 msgstr "Descartar"
 
-#: src/client.c:1255
-msgid "Exchange"
-msgstr ""
-
-#: src/client.c:1607
-msgid "Click a 2, then choose value and suit to assign."
-msgstr ""
-
-#: src/client.c:2467
+#: src/client.c:2369
 msgid "Cancel"
 msgstr ""
 
-#: src/client.c:2474 src/client.c:2490
+#: src/client.c:2376 src/client.c:2392
 #, c-format
 msgid "Attempting connection to: %s... (%d/%d)"
 msgstr ""
@@ -122,51 +118,60 @@ msgstr " Canal de Discord (en el servidor del proyecto Lazarus) "
 msgid "Website"
 msgstr ""
 
-#: src/server.c:92
+#: src/server.c:93
 #, c-format
 msgid ""
 "Warning: password is set but this build lacks libsodium; authentication is "
 "disabled and the password will be ignored.\n"
 msgstr ""
 
-#: src/server.c:678
+#: src/server.c:612
 #, fuzzy
 msgid "checked"
 msgstr "Pasar"
 
-#: src/server.c:692
+#: src/server.c:626
 msgid "folded"
 msgstr ""
 
-#: src/server.c:883
+#: src/server.c:817 src/server.c:839
+msgid "completed "
+msgstr ""
+
+#: src/server.c:817
 msgid "bet "
 msgstr ""
 
-#: src/server.c:897
+#: src/server.c:831
 msgid "called"
 msgstr ""
 
-#: src/server.c:903
+#: src/server.c:848
 #, fuzzy
 msgid "raised "
 msgstr "Subir"
 
-#: src/server.c:1030
+#: src/server.c:975
 #, c-format
 msgid "%s disconnected"
 msgstr ""
 
-#: src/server.c:1046
+#: src/server.c:991
 #, c-format
 msgid "%s was kicked"
 msgstr ""
 
-#: src/server.c:1063
+#: src/server.c:1008
 #, c-format
 msgid "%s was banned"
 msgstr ""
 
-#: src/server.c:1374
+#: src/server.c:1245
+#, c-format
+msgid "%s brings in for %u"
+msgstr ""
+
+#: src/server.c:1411
 #, c-format
 msgid "Game: %s%s"
 msgstr ""

--- a/po/es_CO.po
+++ b/po/es_CO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dealers-choice\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-31 23:08-0500\n"
+"POT-Creation-Date: 2026-04-08 16:31-0500\n"
 "PO-Revision-Date: 2025-07-02 00:18-0500\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -41,56 +41,52 @@ msgstr ""
 msgid "Waiting for dealer to select game..."
 msgstr ""
 
-#: src/client.c:188 src/client.c:1662
+#: src/client.c:188 src/client.c:1608
 msgid "Kick"
 msgstr ""
 
-#: src/client.c:190 src/client.c:1664
+#: src/client.c:190 src/client.c:1610
 msgid "Ban"
 msgstr ""
 
 #. Show dealing screen immediately after click
-#: src/client.c:519
+#: src/client.c:521
 msgid "Dealing..."
 msgstr ""
 
-#: src/client.c:1252
+#: src/client.c:1239
 msgid "Check"
 msgstr "Pasar"
 
-#: src/client.c:1252
+#: src/client.c:1239
 msgid "Bet"
 msgstr "Apostar"
 
-#: src/client.c:1253
+#: src/client.c:1240
 msgid "Fold"
 msgstr "Retirarse"
 
-#: src/client.c:1253
+#: src/client.c:1240
 msgid "Call"
 msgstr "Igualar"
 
-#: src/client.c:1254
+#: src/client.c:1241
 msgid "Raise"
 msgstr "Subir la apuesta"
 
-#: src/client.c:1254
+#: src/client.c:1241
+msgid "Complete"
+msgstr ""
+
+#: src/client.c:1242
 msgid "Discard"
 msgstr "Descartar"
 
-#: src/client.c:1255
-msgid "Exchange"
-msgstr ""
-
-#: src/client.c:1607
-msgid "Click a 2, then choose value and suit to assign."
-msgstr ""
-
-#: src/client.c:2467
+#: src/client.c:2369
 msgid "Cancel"
 msgstr ""
 
-#: src/client.c:2474 src/client.c:2490
+#: src/client.c:2376 src/client.c:2392
 #, c-format
 msgid "Attempting connection to: %s... (%d/%d)"
 msgstr ""
@@ -122,51 +118,60 @@ msgstr " Canal de Discord (en el servidor del proyecto Lazarus) "
 msgid "Website"
 msgstr ""
 
-#: src/server.c:92
+#: src/server.c:93
 #, c-format
 msgid ""
 "Warning: password is set but this build lacks libsodium; authentication is "
 "disabled and the password will be ignored.\n"
 msgstr ""
 
-#: src/server.c:678
+#: src/server.c:612
 #, fuzzy
 msgid "checked"
 msgstr "Pasar"
 
-#: src/server.c:692
+#: src/server.c:626
 msgid "folded"
 msgstr ""
 
-#: src/server.c:883
+#: src/server.c:817 src/server.c:839
+msgid "completed "
+msgstr ""
+
+#: src/server.c:817
 msgid "bet "
 msgstr ""
 
-#: src/server.c:897
+#: src/server.c:831
 msgid "called"
 msgstr ""
 
-#: src/server.c:903
+#: src/server.c:848
 #, fuzzy
 msgid "raised "
 msgstr "Subir la apuesta"
 
-#: src/server.c:1030
+#: src/server.c:975
 #, c-format
 msgid "%s disconnected"
 msgstr ""
 
-#: src/server.c:1046
+#: src/server.c:991
 #, c-format
 msgid "%s was kicked"
 msgstr ""
 
-#: src/server.c:1063
+#: src/server.c:1008
 #, c-format
 msgid "%s was banned"
 msgstr ""
 
-#: src/server.c:1374
+#: src/server.c:1245
+#, c-format
+msgid "%s brings in for %u"
+msgstr ""
+
+#: src/server.c:1411
 #, c-format
 msgid "Game: %s%s"
 msgstr ""

--- a/po/es_MX.po
+++ b/po/es_MX.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dealers-choice\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-31 23:08-0500\n"
+"POT-Creation-Date: 2026-04-08 16:31-0500\n"
 "PO-Revision-Date: 2025-07-02 00:18-0500\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -41,56 +41,52 @@ msgstr ""
 msgid "Waiting for dealer to select game..."
 msgstr ""
 
-#: src/client.c:188 src/client.c:1662
+#: src/client.c:188 src/client.c:1608
 msgid "Kick"
 msgstr ""
 
-#: src/client.c:190 src/client.c:1664
+#: src/client.c:190 src/client.c:1610
 msgid "Ban"
 msgstr ""
 
 #. Show dealing screen immediately after click
-#: src/client.c:519
+#: src/client.c:521
 msgid "Dealing..."
 msgstr ""
 
-#: src/client.c:1252
+#: src/client.c:1239
 msgid "Check"
 msgstr "Pasar"
 
-#: src/client.c:1252
+#: src/client.c:1239
 msgid "Bet"
 msgstr "Apostar"
 
-#: src/client.c:1253
+#: src/client.c:1240
 msgid "Fold"
 msgstr "Retirarse"
 
-#: src/client.c:1253
+#: src/client.c:1240
 msgid "Call"
 msgstr "Igualar"
 
-#: src/client.c:1254
+#: src/client.c:1241
 msgid "Raise"
 msgstr "Subir la apuesta"
 
-#: src/client.c:1254
+#: src/client.c:1241
+msgid "Complete"
+msgstr ""
+
+#: src/client.c:1242
 msgid "Discard"
 msgstr "Descartar"
 
-#: src/client.c:1255
-msgid "Exchange"
-msgstr ""
-
-#: src/client.c:1607
-msgid "Click a 2, then choose value and suit to assign."
-msgstr ""
-
-#: src/client.c:2467
+#: src/client.c:2369
 msgid "Cancel"
 msgstr ""
 
-#: src/client.c:2474 src/client.c:2490
+#: src/client.c:2376 src/client.c:2392
 #, c-format
 msgid "Attempting connection to: %s... (%d/%d)"
 msgstr ""
@@ -122,51 +118,60 @@ msgstr " Canal de Discord (en el servidor del proyecto Lazarus) "
 msgid "Website"
 msgstr ""
 
-#: src/server.c:92
+#: src/server.c:93
 #, c-format
 msgid ""
 "Warning: password is set but this build lacks libsodium; authentication is "
 "disabled and the password will be ignored.\n"
 msgstr ""
 
-#: src/server.c:678
+#: src/server.c:612
 #, fuzzy
 msgid "checked"
 msgstr "Pasar"
 
-#: src/server.c:692
+#: src/server.c:626
 msgid "folded"
 msgstr ""
 
-#: src/server.c:883
+#: src/server.c:817 src/server.c:839
+msgid "completed "
+msgstr ""
+
+#: src/server.c:817
 msgid "bet "
 msgstr ""
 
-#: src/server.c:897
+#: src/server.c:831
 msgid "called"
 msgstr ""
 
-#: src/server.c:903
+#: src/server.c:848
 #, fuzzy
 msgid "raised "
 msgstr "Subir la apuesta"
 
-#: src/server.c:1030
+#: src/server.c:975
 #, c-format
 msgid "%s disconnected"
 msgstr ""
 
-#: src/server.c:1046
+#: src/server.c:991
 #, c-format
 msgid "%s was kicked"
 msgstr ""
 
-#: src/server.c:1063
+#: src/server.c:1008
 #, c-format
 msgid "%s was banned"
 msgstr ""
 
-#: src/server.c:1374
+#: src/server.c:1245
+#, c-format
+msgid "%s brings in for %u"
+msgstr ""
+
+#: src/server.c:1411
 #, c-format
 msgid "Game: %s%s"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dealers-choice\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-31 23:08-0500\n"
+"POT-Creation-Date: 2026-04-08 16:31-0500\n"
 "PO-Revision-Date: 2025-07-02 00:18-0500\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -41,56 +41,52 @@ msgstr ""
 msgid "Waiting for dealer to select game..."
 msgstr ""
 
-#: src/client.c:188 src/client.c:1662
+#: src/client.c:188 src/client.c:1608
 msgid "Kick"
 msgstr ""
 
-#: src/client.c:190 src/client.c:1664
+#: src/client.c:190 src/client.c:1610
 msgid "Ban"
 msgstr ""
 
 #. Show dealing screen immediately after click
-#: src/client.c:519
+#: src/client.c:521
 msgid "Dealing..."
 msgstr ""
 
-#: src/client.c:1252
+#: src/client.c:1239
 msgid "Check"
 msgstr "Parole"
 
-#: src/client.c:1252
+#: src/client.c:1239
 msgid "Bet"
 msgstr "Miser"
 
-#: src/client.c:1253
+#: src/client.c:1240
 msgid "Fold"
 msgstr "Se coucher"
 
-#: src/client.c:1253
+#: src/client.c:1240
 msgid "Call"
 msgstr "Suivre"
 
-#: src/client.c:1254
+#: src/client.c:1241
 msgid "Raise"
 msgstr "Relancer"
 
-#: src/client.c:1254
+#: src/client.c:1241
+msgid "Complete"
+msgstr ""
+
+#: src/client.c:1242
 msgid "Discard"
 msgstr "Défausser"
 
-#: src/client.c:1255
-msgid "Exchange"
-msgstr ""
-
-#: src/client.c:1607
-msgid "Click a 2, then choose value and suit to assign."
-msgstr ""
-
-#: src/client.c:2467
+#: src/client.c:2369
 msgid "Cancel"
 msgstr ""
 
-#: src/client.c:2474 src/client.c:2490
+#: src/client.c:2376 src/client.c:2392
 #, c-format
 msgid "Attempting connection to: %s... (%d/%d)"
 msgstr ""
@@ -122,51 +118,60 @@ msgstr " Canal Discord (sur le serveur du projet Lazarus) "
 msgid "Website"
 msgstr ""
 
-#: src/server.c:92
+#: src/server.c:93
 #, c-format
 msgid ""
 "Warning: password is set but this build lacks libsodium; authentication is "
 "disabled and the password will be ignored.\n"
 msgstr ""
 
-#: src/server.c:678
+#: src/server.c:612
 #, fuzzy
 msgid "checked"
 msgstr "Parole"
 
-#: src/server.c:692
+#: src/server.c:626
 msgid "folded"
 msgstr ""
 
-#: src/server.c:883
+#: src/server.c:817 src/server.c:839
+msgid "completed "
+msgstr ""
+
+#: src/server.c:817
 msgid "bet "
 msgstr ""
 
-#: src/server.c:897
+#: src/server.c:831
 msgid "called"
 msgstr ""
 
-#: src/server.c:903
+#: src/server.c:848
 #, fuzzy
 msgid "raised "
 msgstr "Relancer"
 
-#: src/server.c:1030
+#: src/server.c:975
 #, c-format
 msgid "%s disconnected"
 msgstr ""
 
-#: src/server.c:1046
+#: src/server.c:991
 #, c-format
 msgid "%s was kicked"
 msgstr ""
 
-#: src/server.c:1063
+#: src/server.c:1008
 #, c-format
 msgid "%s was banned"
 msgstr ""
 
-#: src/server.c:1374
+#: src/server.c:1245
+#, c-format
+msgid "%s brings in for %u"
+msgstr ""
+
+#: src/server.c:1411
 #, c-format
 msgid "Game: %s%s"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dealers-choice\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-31 23:08-0500\n"
+"POT-Creation-Date: 2026-04-08 16:31-0500\n"
 "PO-Revision-Date: 2025-07-02 00:46-0500\n"
 "Last-Translator: Andy <andy@prometheus.localhost.localdomain>\n"
 "Language-Team: Italian <tp@lists.linux.it>\n"
@@ -41,56 +41,52 @@ msgstr ""
 msgid "Waiting for dealer to select game..."
 msgstr ""
 
-#: src/client.c:188 src/client.c:1662
+#: src/client.c:188 src/client.c:1608
 msgid "Kick"
 msgstr ""
 
-#: src/client.c:190 src/client.c:1664
+#: src/client.c:190 src/client.c:1610
 msgid "Ban"
 msgstr ""
 
 #. Show dealing screen immediately after click
-#: src/client.c:519
+#: src/client.c:521
 msgid "Dealing..."
 msgstr ""
 
-#: src/client.c:1252
+#: src/client.c:1239
 msgid "Check"
 msgstr "Check"
 
-#: src/client.c:1252
+#: src/client.c:1239
 msgid "Bet"
 msgstr "Punta"
 
-#: src/client.c:1253
+#: src/client.c:1240
 msgid "Fold"
 msgstr "Molla"
 
-#: src/client.c:1253
+#: src/client.c:1240
 msgid "Call"
 msgstr "Chiamata"
 
-#: src/client.c:1254
+#: src/client.c:1241
 msgid "Raise"
 msgstr "Rilancia"
 
-#: src/client.c:1254
+#: src/client.c:1241
+msgid "Complete"
+msgstr ""
+
+#: src/client.c:1242
 msgid "Discard"
 msgstr "Scarta"
 
-#: src/client.c:1255
-msgid "Exchange"
-msgstr ""
-
-#: src/client.c:1607
-msgid "Click a 2, then choose value and suit to assign."
-msgstr ""
-
-#: src/client.c:2467
+#: src/client.c:2369
 msgid "Cancel"
 msgstr ""
 
-#: src/client.c:2474 src/client.c:2490
+#: src/client.c:2376 src/client.c:2392
 #, c-format
 msgid "Attempting connection to: %s... (%d/%d)"
 msgstr ""
@@ -122,51 +118,60 @@ msgstr "Canale Discord (sul server Lazarus Project)"
 msgid "Website"
 msgstr ""
 
-#: src/server.c:92
+#: src/server.c:93
 #, c-format
 msgid ""
 "Warning: password is set but this build lacks libsodium; authentication is "
 "disabled and the password will be ignored.\n"
 msgstr ""
 
-#: src/server.c:678
+#: src/server.c:612
 #, fuzzy
 msgid "checked"
 msgstr "Check"
 
-#: src/server.c:692
+#: src/server.c:626
 msgid "folded"
 msgstr ""
 
-#: src/server.c:883
+#: src/server.c:817 src/server.c:839
+msgid "completed "
+msgstr ""
+
+#: src/server.c:817
 msgid "bet "
 msgstr ""
 
-#: src/server.c:897
+#: src/server.c:831
 msgid "called"
 msgstr ""
 
-#: src/server.c:903
+#: src/server.c:848
 #, fuzzy
 msgid "raised "
 msgstr "Rilancia"
 
-#: src/server.c:1030
+#: src/server.c:975
 #, c-format
 msgid "%s disconnected"
 msgstr ""
 
-#: src/server.c:1046
+#: src/server.c:991
 #, c-format
 msgid "%s was kicked"
 msgstr ""
 
-#: src/server.c:1063
+#: src/server.c:1008
 #, c-format
 msgid "%s was banned"
 msgstr ""
 
-#: src/server.c:1374
+#: src/server.c:1245
+#, c-format
+msgid "%s brings in for %u"
+msgstr ""
+
+#: src/server.c:1411
 #, c-format
 msgid "Game: %s%s"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dealers-choice\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-31 23:08-0500\n"
+"POT-Creation-Date: 2026-04-08 16:31-0500\n"
 "PO-Revision-Date: 2025-07-02 00:18-0500\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -42,56 +42,52 @@ msgstr ""
 msgid "Waiting for dealer to select game..."
 msgstr ""
 
-#: src/client.c:188 src/client.c:1662
+#: src/client.c:188 src/client.c:1608
 msgid "Kick"
 msgstr ""
 
-#: src/client.c:190 src/client.c:1664
+#: src/client.c:190 src/client.c:1610
 msgid "Ban"
 msgstr ""
 
 #. Show dealing screen immediately after click
-#: src/client.c:519
+#: src/client.c:521
 msgid "Dealing..."
 msgstr ""
 
-#: src/client.c:1252
+#: src/client.c:1239
 msgid "Check"
 msgstr "Чек"
 
-#: src/client.c:1252
+#: src/client.c:1239
 msgid "Bet"
 msgstr "Ставка"
 
-#: src/client.c:1253
+#: src/client.c:1240
 msgid "Fold"
 msgstr "Пас"
 
-#: src/client.c:1253
+#: src/client.c:1240
 msgid "Call"
 msgstr "Колл"
 
-#: src/client.c:1254
+#: src/client.c:1241
 msgid "Raise"
 msgstr "Рейз"
 
-#: src/client.c:1254
+#: src/client.c:1241
+msgid "Complete"
+msgstr ""
+
+#: src/client.c:1242
 msgid "Discard"
 msgstr "Сбросить"
 
-#: src/client.c:1255
-msgid "Exchange"
-msgstr ""
-
-#: src/client.c:1607
-msgid "Click a 2, then choose value and suit to assign."
-msgstr ""
-
-#: src/client.c:2467
+#: src/client.c:2369
 msgid "Cancel"
 msgstr ""
 
-#: src/client.c:2474 src/client.c:2490
+#: src/client.c:2376 src/client.c:2392
 #, c-format
 msgid "Attempting connection to: %s... (%d/%d)"
 msgstr ""
@@ -123,51 +119,60 @@ msgstr " Канал Discord (на сервере проекта Lazarus) "
 msgid "Website"
 msgstr ""
 
-#: src/server.c:92
+#: src/server.c:93
 #, c-format
 msgid ""
 "Warning: password is set but this build lacks libsodium; authentication is "
 "disabled and the password will be ignored.\n"
 msgstr ""
 
-#: src/server.c:678
+#: src/server.c:612
 #, fuzzy
 msgid "checked"
 msgstr "Чек"
 
-#: src/server.c:692
+#: src/server.c:626
 msgid "folded"
 msgstr ""
 
-#: src/server.c:883
+#: src/server.c:817 src/server.c:839
+msgid "completed "
+msgstr ""
+
+#: src/server.c:817
 msgid "bet "
 msgstr ""
 
-#: src/server.c:897
+#: src/server.c:831
 msgid "called"
 msgstr ""
 
-#: src/server.c:903
+#: src/server.c:848
 #, fuzzy
 msgid "raised "
 msgstr "Рейз"
 
-#: src/server.c:1030
+#: src/server.c:975
 #, c-format
 msgid "%s disconnected"
 msgstr ""
 
-#: src/server.c:1046
+#: src/server.c:991
 #, c-format
 msgid "%s was kicked"
 msgstr ""
 
-#: src/server.c:1063
+#: src/server.c:1008
 #, c-format
 msgid "%s was banned"
 msgstr ""
 
-#: src/server.c:1374
+#: src/server.c:1245
+#, c-format
+msgid "%s brings in for %u"
+msgstr ""
+
+#: src/server.c:1411
 #, c-format
 msgid "Game: %s%s"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dealers-choice\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-31 23:08-0500\n"
+"POT-Creation-Date: 2026-04-08 16:31-0500\n"
 "PO-Revision-Date: 2026-03-08 15:06-0500\n"
 "Last-Translator: Andy <arch_stanton5995@proton.me>\n"
 "Language-Team: \n"
@@ -41,56 +41,52 @@ msgstr ""
 msgid "Waiting for dealer to select game..."
 msgstr ""
 
-#: src/client.c:188 src/client.c:1662
+#: src/client.c:188 src/client.c:1608
 msgid "Kick"
 msgstr ""
 
-#: src/client.c:190 src/client.c:1664
+#: src/client.c:190 src/client.c:1610
 msgid "Ban"
 msgstr ""
 
 #. Show dealing screen immediately after click
-#: src/client.c:519
+#: src/client.c:521
 msgid "Dealing..."
 msgstr "Delar ut..."
 
-#: src/client.c:1252
+#: src/client.c:1239
 msgid "Check"
 msgstr "Passa"
 
-#: src/client.c:1252
+#: src/client.c:1239
 msgid "Bet"
 msgstr "Satsa"
 
-#: src/client.c:1253
+#: src/client.c:1240
 msgid "Fold"
 msgstr "Lägg dig"
 
-#: src/client.c:1253
+#: src/client.c:1240
 msgid "Call"
 msgstr "Syna"
 
-#: src/client.c:1254
+#: src/client.c:1241
 msgid "Raise"
 msgstr "Höj"
 
-#: src/client.c:1254
+#: src/client.c:1241
+msgid "Complete"
+msgstr ""
+
+#: src/client.c:1242
 msgid "Discard"
 msgstr "Kasta"
 
-#: src/client.c:1255
-msgid "Exchange"
-msgstr "Byt"
-
-#: src/client.c:1607
-msgid "Click a 2, then choose value and suit to assign."
-msgstr "Klicka på en tvåa och välj sedan valör och färg att tilldela."
-
-#: src/client.c:2467
+#: src/client.c:2369
 msgid "Cancel"
 msgstr ""
 
-#: src/client.c:2474 src/client.c:2490
+#: src/client.c:2376 src/client.c:2392
 #, c-format
 msgid "Attempting connection to: %s... (%d/%d)"
 msgstr ""
@@ -121,54 +117,69 @@ msgstr "Discord-kanal (på Lazarus Project-servern)"
 msgid "Website"
 msgstr "Webbplats"
 
-#: src/server.c:92
+#: src/server.c:93
 #, c-format
 msgid ""
 "Warning: password is set but this build lacks libsodium; authentication is "
 "disabled and the password will be ignored.\n"
 msgstr ""
 
-#: src/server.c:678
+#: src/server.c:612
 #, fuzzy
 msgid "checked"
 msgstr "Passa"
 
-#: src/server.c:692
+#: src/server.c:626
 msgid "folded"
 msgstr ""
 
-#: src/server.c:883
+#: src/server.c:817 src/server.c:839
+msgid "completed "
+msgstr ""
+
+#: src/server.c:817
 msgid "bet "
 msgstr ""
 
-#: src/server.c:897
+#: src/server.c:831
 msgid "called"
 msgstr ""
 
-#: src/server.c:903
+#: src/server.c:848
 #, fuzzy
 msgid "raised "
 msgstr "Höj"
 
-#: src/server.c:1030
+#: src/server.c:975
 #, c-format
 msgid "%s disconnected"
 msgstr ""
 
-#: src/server.c:1046
+#: src/server.c:991
 #, c-format
 msgid "%s was kicked"
 msgstr ""
 
-#: src/server.c:1063
+#: src/server.c:1008
 #, c-format
 msgid "%s was banned"
 msgstr ""
 
-#: src/server.c:1374
+#: src/server.c:1245
+#, c-format
+msgid "%s brings in for %u"
+msgstr ""
+
+#: src/server.c:1411
 #, c-format
 msgid "Game: %s%s"
 msgstr ""
+
+#~ msgid "Exchange"
+#~ msgstr "Byt"
+
+#~ msgid "Click a 2, then choose value and suit to assign."
+#~ msgstr "Klicka på en tvåa och välj sedan valör och färg att tilldela."
 
 #~ msgid "Connected players:"
 #~ msgstr "Anslutna spelare:"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dealers-choice\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-31 23:08-0500\n"
+"POT-Creation-Date: 2026-04-08 16:31-0500\n"
 "PO-Revision-Date: 2025-07-02 00:18-0500\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -42,56 +42,52 @@ msgstr ""
 msgid "Waiting for dealer to select game..."
 msgstr ""
 
-#: src/client.c:188 src/client.c:1662
+#: src/client.c:188 src/client.c:1608
 msgid "Kick"
 msgstr ""
 
-#: src/client.c:190 src/client.c:1664
+#: src/client.c:190 src/client.c:1610
 msgid "Ban"
 msgstr ""
 
 #. Show dealing screen immediately after click
-#: src/client.c:519
+#: src/client.c:521
 msgid "Dealing..."
 msgstr ""
 
-#: src/client.c:1252
+#: src/client.c:1239
 msgid "Check"
 msgstr "Чек"
 
-#: src/client.c:1252
+#: src/client.c:1239
 msgid "Bet"
 msgstr "Ставка"
 
-#: src/client.c:1253
+#: src/client.c:1240
 msgid "Fold"
 msgstr "Пас"
 
-#: src/client.c:1253
+#: src/client.c:1240
 msgid "Call"
 msgstr "Кол"
 
-#: src/client.c:1254
+#: src/client.c:1241
 msgid "Raise"
 msgstr "Рейз"
 
-#: src/client.c:1254
+#: src/client.c:1241
+msgid "Complete"
+msgstr ""
+
+#: src/client.c:1242
 msgid "Discard"
 msgstr "Скинути"
 
-#: src/client.c:1255
-msgid "Exchange"
-msgstr ""
-
-#: src/client.c:1607
-msgid "Click a 2, then choose value and suit to assign."
-msgstr ""
-
-#: src/client.c:2467
+#: src/client.c:2369
 msgid "Cancel"
 msgstr ""
 
-#: src/client.c:2474 src/client.c:2490
+#: src/client.c:2376 src/client.c:2392
 #, c-format
 msgid "Attempting connection to: %s... (%d/%d)"
 msgstr ""
@@ -123,51 +119,60 @@ msgstr " Канал Discord (на сервері проєкту Lazarus) "
 msgid "Website"
 msgstr ""
 
-#: src/server.c:92
+#: src/server.c:93
 #, c-format
 msgid ""
 "Warning: password is set but this build lacks libsodium; authentication is "
 "disabled and the password will be ignored.\n"
 msgstr ""
 
-#: src/server.c:678
+#: src/server.c:612
 #, fuzzy
 msgid "checked"
 msgstr "Чек"
 
-#: src/server.c:692
+#: src/server.c:626
 msgid "folded"
 msgstr ""
 
-#: src/server.c:883
+#: src/server.c:817 src/server.c:839
+msgid "completed "
+msgstr ""
+
+#: src/server.c:817
 msgid "bet "
 msgstr ""
 
-#: src/server.c:897
+#: src/server.c:831
 msgid "called"
 msgstr ""
 
-#: src/server.c:903
+#: src/server.c:848
 #, fuzzy
 msgid "raised "
 msgstr "Рейз"
 
-#: src/server.c:1030
+#: src/server.c:975
 #, c-format
 msgid "%s disconnected"
 msgstr ""
 
-#: src/server.c:1046
+#: src/server.c:991
 #, c-format
 msgid "%s was kicked"
 msgstr ""
 
-#: src/server.c:1063
+#: src/server.c:1008
 #, c-format
 msgid "%s was banned"
 msgstr ""
 
-#: src/server.c:1374
+#: src/server.c:1245
+#, c-format
+msgid "%s brings in for %u"
+msgstr ""
+
+#: src/server.c:1411
 #, c-format
 msgid "Game: %s%s"
 msgstr ""

--- a/src/client.c
+++ b/src/client.c
@@ -964,7 +964,7 @@ static void draw_card_back_pattern(SDL_Renderer *renderer, SDL_Rect *card_rect) 
 }
 
 int send_player_action(ClientState_t *client_state, TCPsocket sock, uint8_t action,
-                          uint32_t amount) {
+                       uint32_t amount) {
   uint8_t buffer[7];
 
   buffer[0] = (MSG_PLAYER_ACTION >> 8) & 0xFF;
@@ -982,8 +982,7 @@ int send_player_action(ClientState_t *client_state, TCPsocket sock, uint8_t acti
   return send_all_tcp(sock, buffer, sizeof(buffer));
 }
 
-int send_discards_request_new_cards(TCPsocket sock, const uint8_t *discard_indices,
-                                       uint8_t count) {
+int send_discards_request_new_cards(TCPsocket sock, const uint8_t *discard_indices, uint8_t count) {
   if (count > 4)
     return -1;
 
@@ -1216,6 +1215,7 @@ enum {
   FOLD,
   CALL,
   RAISE,
+  COMPLETE,
   DISCARD,
   MAX_ACTIONS,
 };
@@ -1236,9 +1236,10 @@ typedef struct {
 } ActionButtonAttrs;
 
 ActionButtonAttrs action_button_attrs[MAX_ACTIONS] = {
-    [CHECK] = {N_("Check"), SDLK_c, false},      [BET] = {N_("Bet"), SDLK_b, false},
-    [FOLD] = {N_("Fold"), SDLK_f, false},        [CALL] = {N_("Call"), SDLK_c, false},
-    [RAISE] = {N_("Raise"), SDLK_r, false},      [DISCARD] = {N_("Discard"), SDLK_d, true},
+    [CHECK] = {N_("Check"), SDLK_c, false},    [BET] = {N_("Bet"), SDLK_b, false},
+    [FOLD] = {N_("Fold"), SDLK_f, false},      [CALL] = {N_("Call"), SDLK_c, false},
+    [RAISE] = {N_("Raise"), SDLK_r, false},    [COMPLETE] = {N_("Complete"), SDLK_r, false},
+    [DISCARD] = {N_("Discard"), SDLK_d, true},
 };
 
 static void layout_action_buttons(ButtonWidget_t **b, ActionButtonAttrs *attr) {
@@ -1945,6 +1946,8 @@ static bool handle_game_logic(const PlayerConfig_t *player_config, SocketContext
         // may be set to true
         client_state.bet_check_fold = false;
         client_state.call_raise_fold = false;
+        client_state.call_complete_fold = false;
+        client_state.complete_check_fold = false;
         client_state.do_discard_draw = false;
 
         if (my_turn && !game_state->winner_declared) {
@@ -1983,7 +1986,8 @@ static bool handle_game_logic(const PlayerConfig_t *player_config, SocketContext
           ui_widget_render(&discard_hint_tw->base);
         }
         ui_widget_render(&action_bw[DISCARD]->base);
-      } else if (client_state.bet_check_fold || client_state.call_raise_fold) {
+      } else if (client_state.bet_check_fold || client_state.call_raise_fold ||
+                 client_state.call_complete_fold || client_state.complete_check_fold) {
         int x_offset = x_begin_action_button;
         if (client_state.bet_check_fold) {
           action_bw[BET]->base.rect.x = x_offset;
@@ -2005,14 +2009,38 @@ static bool handle_game_logic(const PlayerConfig_t *player_config, SocketContext
             ui_widget_render(&action_bw[RAISE]->base);
           x_offset =
               action_bw[RAISE]->base.rect.x + action_bw[RAISE]->base.rect.w + BUTTON_X_SPACING;
+        } else if (client_state.call_complete_fold) {
+          action_bw[CALL]->base.rect.x = x_offset;
+          ui_widget_render(&action_bw[CALL]->base);
+          x_offset = action_bw[CALL]->base.rect.x + action_bw[CALL]->base.rect.w + BUTTON_X_SPACING;
+
+          action_bw[COMPLETE]->base.rect.x = x_offset;
+          action_bw[COMPLETE]->interactive = game_state->raises_remaining > 0;
+          if (action_bw[COMPLETE]->interactive)
+            ui_widget_render(&action_bw[COMPLETE]->base);
+          x_offset = action_bw[COMPLETE]->base.rect.x + action_bw[COMPLETE]->base.rect.w +
+                     BUTTON_X_SPACING;
+        } else if (client_state.complete_check_fold) {
+          action_bw[COMPLETE]->base.rect.x = x_offset;
+          action_bw[COMPLETE]->interactive = game_state->raises_remaining > 0;
+          if (action_bw[COMPLETE]->interactive)
+            ui_widget_render(&action_bw[COMPLETE]->base);
+          x_offset = action_bw[COMPLETE]->base.rect.x + action_bw[COMPLETE]->base.rect.w +
+                     BUTTON_X_SPACING;
+
+          action_bw[CHECK]->base.rect.x = x_offset;
+          ui_widget_render(&action_bw[CHECK]->base);
+          x_offset =
+              action_bw[CHECK]->base.rect.x + action_bw[CHECK]->base.rect.w + BUTTON_X_SPACING;
         }
         action_bw[FOLD]->base.rect.x = x_offset;
         ui_widget_render(&action_bw[FOLD]->base);
 
         // The amount buttons won't be shown if this is true (max raises were reached
         // if the RAISE button is not active).
-        if (client_state.bet_check_fold ||
-            (client_state.call_raise_fold && action_bw[RAISE]->interactive)) {
+        if (client_state.bet_check_fold || client_state.complete_check_fold ||
+            (client_state.call_raise_fold && action_bw[RAISE]->interactive) ||
+            (client_state.call_complete_fold && action_bw[COMPLETE]->interactive)) {
           for (size_t i = 0; i < n_bet_amounts; i++) {
             if (game_state->prev_bet_amount > amount[i].value && action_bw[RAISE]->interactive)
               amount_bw[i]->interactive = false;
@@ -2159,7 +2187,8 @@ static bool handle_game_logic(const PlayerConfig_t *player_config, SocketContext
       }
       if (event.type == SDL_MOUSEBUTTONDOWN || event.type == SDL_KEYDOWN) {
         if (my_turn && !client_state.do_discard_draw) {
-          if (client_state.bet_check_fold || client_state.call_raise_fold) {
+          if (client_state.bet_check_fold || client_state.call_raise_fold ||
+              client_state.call_complete_fold || client_state.complete_check_fold) {
             if (SDL_PointInRect(&mouse_pos, &action_bw[FOLD]->base.rect) ||
                 event.key.keysym.sym == action_bw[FOLD]->hotkey) {
               verbose_puts("folding");
@@ -2195,6 +2224,36 @@ static bool handle_game_logic(const PlayerConfig_t *player_config, SocketContext
               verbose_puts("calling");
               if (send_player_action(&client_state, sock, ACTION_CALL, 0) != 0)
                 fprintf(stderr, "Failed to call\n");
+            }
+          } else if (client_state.call_complete_fold) {
+            if (action_bw[COMPLETE]->interactive &&
+                (SDL_PointInRect(&mouse_pos, &action_bw[COMPLETE]->base.rect) ||
+                 event.key.keysym.sym == action_bw[COMPLETE]->hotkey)) {
+              if (send_player_action(&client_state, sock, ACTION_BET,
+                                     client_state.selected_amount) == 0)
+                verbose_printf("completing %d\n", client_state.selected_amount);
+              else
+                fputs("Failed to complete\n", stderr);
+            } else if (SDL_PointInRect(&mouse_pos, &action_bw[CALL]->base.rect) ||
+                       event.key.keysym.sym == action_bw[CALL]->hotkey) {
+              verbose_puts("calling");
+              if (send_player_action(&client_state, sock, ACTION_CALL, 0) != 0)
+                fprintf(stderr, "Failed to call\n");
+            }
+          } else if (client_state.complete_check_fold) {
+            if (action_bw[COMPLETE]->interactive &&
+                (SDL_PointInRect(&mouse_pos, &action_bw[COMPLETE]->base.rect) ||
+                 event.key.keysym.sym == action_bw[COMPLETE]->hotkey)) {
+              if (send_player_action(&client_state, sock, ACTION_BET,
+                                     client_state.selected_amount) == 0)
+                verbose_printf("completing %d\n", client_state.selected_amount);
+              else
+                fputs("Failed to complete\n", stderr);
+            } else if (SDL_PointInRect(&mouse_pos, &action_bw[CHECK]->base.rect) ||
+                       event.key.keysym.sym == action_bw[CHECK]->hotkey) {
+              verbose_puts("checking");
+              if (send_player_action(&client_state, sock, ACTION_CHECK, 0) != 0)
+                fprintf(stderr, "Failed to check\n");
             }
           }
         } else if (action_bw[DISCARD]->interactive && client_state.do_discard_draw &&
@@ -2597,7 +2656,7 @@ bool get_socket_context_and_run_client(PlayerConfig_t *player_config, const CliA
       } while (running);
       went_back_result = went_back;
     }
-cleanup_audio:
+  cleanup_audio:
     for (i = 0; i < n_sounds_init; i++)
       ma_sound_uninit(&sounds[i].sound);
     for (i = 0; i < n_coin_sounds_init; i++)

--- a/src/client.h
+++ b/src/client.h
@@ -80,8 +80,7 @@ int send_player_action(ClientState_t *client_state, TCPsocket sock, uint8_t acti
 
 void do_sdl_cleanup(SdlContext_t *sdl_context);
 
-int send_discards_request_new_cards(TCPsocket sock, const uint8_t *discard_indices,
-                                    uint8_t count);
+int send_discards_request_new_cards(TCPsocket sock, const uint8_t *discard_indices, uint8_t count);
 
 void layout_cards(CardContext_t card_context[MAX_PLAYERS][MAX_HAND_SIZE], Player_t *players_array,
                   const SDL_Point *player_pos);

--- a/src/dc_config.c
+++ b/src/dc_config.c
@@ -32,7 +32,7 @@
 #include <string.h>
 
 #ifdef _MSC_VER
-#  define strcasecmp _stricmp
+#define strcasecmp _stricmp
 #endif
 
 #include "dc_config.h"

--- a/src/dc_config.h
+++ b/src/dc_config.h
@@ -42,6 +42,7 @@ typedef struct ServerConfig_t {
   uint32_t action_timeout_ms;
   uint32_t dealer_timeout_ms;
   uint32_t ante;
+  uint32_t bringin_amount;
   int32_t starting_coins;
   uint32_t max_raises;
   uint32_t bet_amounts[MAX_BET_AMOUNTS];
@@ -108,6 +109,8 @@ static const ConfigEntry server_config_entries[] = {
     {"dealer_timeout_ms", CFG_TYPE_UINT32, "60000", offsetof(ServerConfig_t, dealer_timeout_ms),
      sizeof(uint32_t)},
     {"ante", CFG_TYPE_UINT32, "50", offsetof(ServerConfig_t, ante), sizeof(uint32_t)},
+    {"bringin_amount", CFG_TYPE_UINT32, "50", offsetof(ServerConfig_t, bringin_amount),
+     sizeof(uint32_t)},
     {"starting_coins", CFG_TYPE_INT, "20000", offsetof(ServerConfig_t, starting_coins),
      sizeof(int32_t)},
     {"max_raises", CFG_TYPE_UINT32, "3", offsetof(ServerConfig_t, max_raises), sizeof(uint32_t)},

--- a/src/game.c
+++ b/src/game.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <time.h>
 #ifndef _MSC_VER
-#  include <unistd.h>
+#include <unistd.h>
 #endif
 
 #include "game.h"

--- a/src/game.h
+++ b/src/game.h
@@ -34,7 +34,7 @@
 #include <stdio.h>
 #include <string.h>
 #ifndef _MSC_VER
-#  include <unistd.h>
+#include <unistd.h>
 #endif
 
 #include "config.h"

--- a/src/net.c
+++ b/src/net.c
@@ -354,6 +354,12 @@ ERecvStatus_t recv_game_state(SocketContext_t *socket_context, GameState_t *game
   case MSG_CALL_RAISE_FOLD:
     client_state->call_raise_fold = true;
     break;
+  case MSG_CALL_COMPLETE_FOLD:
+    client_state->call_complete_fold = true;
+    break;
+  case MSG_COMPLETE_CHECK_FOLD:
+    client_state->complete_check_fold = true;
+    break;
   case MSG_DRAW_PROMPT:
     if (size != 2) {
       fprintf(stderr, "[recv_game_state] Invalid size for MSG_DRAW_PROMPT: %u\n", size);

--- a/src/net.h
+++ b/src/net.h
@@ -84,6 +84,9 @@ __attribute__((packed)) GameProtocolHeader_t;
 #define MSG_TURN_ID 0x000E
 #define MSG_KICK_PLAYER 0x000F // Admin kicks a player
 #define MSG_BAN_PLAYER 0x0010  // Admin bans a player by IP
+// Bring-in round opcodes: Complete = raise to the full small bet (not a full raise).
+#define MSG_CALL_COMPLETE_FOLD 0x0011  // Other players: call bring-in, complete, or fold
+#define MSG_COMPLETE_CHECK_FOLD 0x0012 // Bring-in player's second turn: complete or check
 
 #define DEFAULT_PORT "22777"
 
@@ -112,6 +115,8 @@ typedef struct {
   bool play_coin_sound;
   bool bet_check_fold;
   bool call_raise_fold;
+  bool call_complete_fold;
+  bool complete_check_fold;
   unsigned int ping_times[MAX_CLIENTS];
   uint8_t game_type;
   bool deuces_wild;

--- a/src/server.c
+++ b/src/server.c
@@ -47,7 +47,8 @@
 #define SEND_RETRY_DELAY_MS 500
 #define PING_THRESHOLD 1000
 
-#define handle_round() handle_round_real(args)
+#define handle_round() handle_round_real(args, 0, -1)
+#define handle_round_bringin(amt, paid_id) handle_round_real(args, (amt), (paid_id))
 
 typedef struct {
   uint8_t n_winners;
@@ -271,7 +272,7 @@ int send_status_message(TCPsocket sock, const char *msg) {
     msg_len = LEN_STATUS_STR;
 
   uint32_t size = SDL_SwapBE32(2 + (uint32_t)msg_len); // payload: 2-byte opcode + N-byte msg
-  uint8_t buffer[4 + 2 + LEN_STATUS_STR];    // max: 4 bytes (size) + 2 (opcode) + 100 (msg)
+  uint8_t buffer[4 + 2 + LEN_STATUS_STR]; // max: 4 bytes (size) + 2 (opcode) + 100 (msg)
 
   memcpy(buffer, &size, sizeof(size));
 
@@ -737,18 +738,20 @@ static void award_last_player_in_game(ArgsBroadcastGameState_t *args, Player_t *
   return;
 }
 
-static RoundResults handle_round_real(ArgsBroadcastGameState_t *args) {
+static RoundResults handle_round_real(ArgsBroadcastGameState_t *args, uint32_t initial_bet,
+                                      int8_t initial_paid_id) {
   args->game_state->raises_remaining = args->config->max_raises;
-  args->game_state->prev_bet_amount = 0;
+  args->game_state->prev_bet_amount = initial_bet;
 
   Player_t *turn;
-  // printf("%s:turn->id: %d\n", __func__, turn->id);
 
   RoundResults results = {0};
 
   turn = *args->starting_turn;
-  uint32_t total_bets_plus_raises = 0;
+  uint32_t total_bets_plus_raises = initial_bet;
   uint32_t player_total_paid[MAX_PLAYERS] = {0};
+  if (initial_paid_id >= 0 && initial_paid_id < MAX_PLAYERS)
+    player_total_paid[initial_paid_id] = initial_bet;
   uint8_t num_turns = 0;
 
   do {
@@ -760,7 +763,17 @@ static RoundResults handle_round_real(ArgsBroadcastGameState_t *args) {
     uint32_t start = SDL_GetTicks();
     PlayerActionMsg_t action = {0};
 
-    uint16_t opcode = total_bets_plus_raises == 0 ? MSG_BET_CHECK_FOLD : MSG_CALL_RAISE_FOLD;
+    uint32_t owed = (player_total_paid[turn->id] < total_bets_plus_raises)
+                        ? total_bets_plus_raises - player_total_paid[turn->id]
+                        : 0;
+    // In the bring-in round (initial_bet > 0) and before anyone has completed or
+    // raised (total == initial_bet), use the more accurate Complete opcodes.
+    bool bringin_round_unopened = (initial_bet > 0 && total_bets_plus_raises == initial_bet);
+    uint16_t opcode;
+    if (owed > 0)
+      opcode = bringin_round_unopened ? MSG_CALL_COMPLETE_FOLD : MSG_CALL_RAISE_FOLD;
+    else
+      opcode = bringin_round_unopened ? MSG_COMPLETE_CHECK_FOLD : MSG_BET_CHECK_FOLD;
     if (send_opcode(args->clients[turn->id], opcode) != 0)
       fputs("Error sending action prompt", stderr);
 
@@ -788,15 +801,20 @@ static RoundResults handle_round_real(ArgsBroadcastGameState_t *args) {
             }
             continue;
           } else if (msg_type == TURN_MSG_ACTION) {
-            if (opcode == MSG_BET_CHECK_FOLD) {
+            if (opcode == MSG_BET_CHECK_FOLD || opcode == MSG_COMPLETE_CHECK_FOLD) {
               switch (action.action) {
               case ACTION_CHECK:
                 handle_check(&action);
                 break;
               case ACTION_BET:
+                // Completing the bring-in (COMPLETE_CHECK_FOLD) or opening a new
+                // bet (BET_CHECK_FOLD) both count against the raise cap when there
+                // is already money in the pot.
+                if (total_bets_plus_raises > 0 && args->game_state->raises_remaining > 0)
+                  args->game_state->raises_remaining--;
                 server_handle_bet(args->game_state, &player_total_paid[turn->id], turn->id,
                                   action.amount, &total_bets_plus_raises);
-                action.str = _("bet ");
+                action.str = (opcode == MSG_COMPLETE_CHECK_FOLD) ? _("completed ") : _("bet ");
                 break;
               case ACTION_FOLD:
                 handle_fold(args->game_state, args->real_hand, turn, args->starting_turn, &action);
@@ -811,6 +829,17 @@ static RoundResults handle_round_real(ArgsBroadcastGameState_t *args) {
                 server_handle_call(args->game_state, &player_total_paid[turn->id], turn->id,
                                    &total_bets_plus_raises);
                 action.str = _("called");
+                break;
+              case ACTION_BET:
+                // Complete: raise to full bet from the bring-in (MSG_CALL_COMPLETE_FOLD).
+                if (opcode == MSG_CALL_COMPLETE_FOLD && args->game_state->raises_remaining > 0) {
+                  args->game_state->raises_remaining--;
+                  server_handle_bet(args->game_state, &player_total_paid[turn->id], turn->id,
+                                    action.amount, &total_bets_plus_raises);
+                  action.str = _("completed ");
+                } else {
+                  fputs("BET received unexpectedly; ignoring\n", stderr);
+                }
                 break;
               case ACTION_RAISE:
                 if (args->game_state->raises_remaining > 0) {
@@ -856,7 +885,7 @@ static RoundResults handle_round_real(ArgsBroadcastGameState_t *args) {
           if (!has_paid_all_bets(player_total_paid[turn->id], total_bets_plus_raises)) {
             action.action =
                 handle_fold(args->game_state, args->real_hand, turn, args->starting_turn, &action);
-          } else if (total_bets_plus_raises == 0) {
+          } else if (owed == 0) {
             action.action = handle_check(&action);
           }
           const uint8_t m = args->config->action_timeout_max;
@@ -1120,13 +1149,118 @@ void game_five_card_draw(GAME_ARGS) {
   determine_winner(args, &results);
 }
 
+// Returns the index of the first face-up card within the initial deal, or -1 if none.
+static int stud_upcard_idx(const GameChoice_t *choice) {
+  for (int i = 0; i < choice->n_cards_initial_deal; i++)
+    if (choice->face_up[i])
+      return i;
+  return -1;
+}
+
+// Returns the player whose upcard at real_hand[][upcard_idx] is lowest (bring-in player).
+static Player_t *stud_find_bringin_player(const ArgsBroadcastGameState_t *args,
+                                          Player_t *players_array, int upcard_idx) {
+  Player_t *bringin = NULL;
+  DH_Card bringin_card = DH_card_null;
+
+  Player_t *turn = *args->starting_turn;
+  do {
+    if (!turn->in || !turn->is_connected) {
+      turn = get_next_player(players_array, turn->id);
+      continue;
+    }
+    DH_Card upcard = args->real_hand->player[turn->id].card[upcard_idx];
+    if (DH_is_card_null(upcard)) {
+      turn = get_next_player(players_array, turn->id);
+      continue;
+    }
+    if (bringin == NULL || POKEVAL_card_bringin_lt(upcard, bringin_card)) {
+      bringin = turn;
+      bringin_card = upcard;
+    }
+    turn = get_next_player(players_array, turn->id);
+  } while (turn && turn != *args->starting_turn);
+
+  return bringin;
+}
+
+// Returns the player with the best visible upcard hand at a given street index.
+// street_idx is the loop variable i (deal index about to be made); visible cards are
+// 0..street_idx-1 where face_up[j] == true.
+static Player_t *stud_find_best_upcard_player(const ArgsBroadcastGameState_t *args,
+                                              Player_t *players_array, const GameChoice_t *choice,
+                                              uint8_t street_idx) {
+  Player_t *best_player = NULL;
+  uint64_t best_score = 0;
+
+  Player_t *turn = *args->starting_turn;
+  do {
+    if (!turn->in || !turn->is_connected) {
+      turn = get_next_player(players_array, turn->id);
+      continue;
+    }
+
+    // Collect this player's visible (face-up) cards dealt so far
+    DH_Card visible[4];
+    int n_visible = 0;
+    for (int j = 0; j < street_idx && n_visible < 4; j++) {
+      if (choice->face_up[j])
+        visible[n_visible++] = args->real_hand->player[turn->id].card[j];
+    }
+
+    uint64_t score = POKEVAL_score_stud_upcards(visible, n_visible);
+    if (best_player == NULL || score > best_score) {
+      best_score = score;
+      best_player = turn;
+    }
+
+    turn = get_next_player(players_array, turn->id);
+  } while (turn && turn != *args->starting_turn);
+
+  return best_player;
+}
+
 void game_stud(GAME_ARGS) {
   Player_t *turn;
   server_handle_ante(args->game_state, args->config->ante);
 
   RoundResults results = {0};
+  bool first_round = true;
+
+  // Find the one face-up card in the initial deal — used to determine the bring-in player.
+  int upcard_idx = stud_upcard_idx(choice);
+
   for (uint8_t i = choice->n_cards_initial_deal; i <= choice->hand_size; i++) {
-    results = handle_round();
+    if (first_round) {
+      // Bring-in: player with the lowest upcard posts a forced partial bet.
+      Player_t *bringin =
+          (upcard_idx >= 0) ? stud_find_bringin_player(args, players_array, upcard_idx) : NULL;
+
+      if (bringin && args->config->bringin_amount > 0) {
+        args->turn_id = bringin->id;
+        bringin->coins -= (int32_t)args->config->bringin_amount;
+        args->game_state->pot += args->config->bringin_amount;
+
+        char bringin_str[LEN_STATUS_STR] = {0};
+        snprintf(bringin_str, sizeof(bringin_str), _("%s brings in for %u"), bringin->nick,
+                 args->config->bringin_amount);
+        broadcast_status_message(args, bringin_str);
+
+        // Action starts with the player to the left of the bring-in player.
+        *args->starting_turn = get_next_player(players_array, bringin->id);
+        broadcast_game_state(args);
+        results = handle_round_bringin(args->config->bringin_amount, bringin->id);
+      } else {
+        results = handle_round();
+      }
+      first_round = false;
+    } else {
+      // Subsequent streets: player with the best visible hand acts first.
+      Player_t *best = stud_find_best_upcard_player(args, players_array, choice, i);
+      if (best)
+        *args->starting_turn = best;
+      results = handle_round();
+    }
 
     if (results.n_winners > 0 || i == choice->hand_size)
       break;
@@ -1143,22 +1277,10 @@ void game_stud(GAME_ARGS) {
         hand->card[i] = args->real_hand->player[id].card[i];
       else
         hand->card[i] = DH_card_back;
-      // broadcast_game_state(args);
       turn = get_next_player(players_array, turn->id);
     } while (turn && turn != *args->starting_turn);
     broadcast_game_state(args);
   }
-
-  // 7-card stud setup (for testing)
-  /*
-  args->real_hand->player[0].card[0].face_val = DH_CARD_KING;
-  args->real_hand->player[0].card[1].face_val = DH_CARD_KING;
-  args->real_hand->player[0].card[2].face_val = DH_CARD_KING;
-  args->real_hand->player[0].card[3].face_val = DH_CARD_ACE;
-  args->real_hand->player[0].card[4].face_val = DH_CARD_THREE;
-  args->real_hand->player[0].card[5].face_val = DH_CARD_JACK;
-  args->real_hand->player[0].card[6].face_val = DH_CARD_TWO;
-  */
 
   determine_winner(args, &results);
 }

--- a/tests/5_card_stud.c
+++ b/tests/5_card_stud.c
@@ -7,6 +7,9 @@ fprintf(stderr, "Dealer %d selecting game\n", *dealer_id);
 assert(send_game_select(socket_context[*dealer_id].sock, game_choices[FIVE_CARD_STUD].game_type,
                         false) == 0);
 
+// Initial deal + game-type broadcast + bring-in status msg + bring-in game state + first turn-id
+_RECEIVE_GAME_STATE()
+_RECEIVE_GAME_STATE()
 _RECEIVE_GAME_STATE()
 _RECEIVE_GAME_STATE()
 _RECEIVE_GAME_STATE()
@@ -16,12 +19,15 @@ for (int n_rounds = 0; n_rounds < game_choices[FIVE_CARD_STUD].n_betting_rounds;
 
   int8_t *turn_id = &client_state[0].turn_id;
 
-  const int expected_bet_turn[] = {1, 2, 0};
-  assert(expected_bet_turn[game] == *turn_id);
-
   SDL_Delay(n_ms);
-  fprintf(stderr, "turn_id: %d sending bet...\n", *turn_id);
-  assert(send_player_action(client_state, socket_context[*turn_id].sock, ACTION_BET, 500) == 0);
+  if (n_rounds == 0) {
+    // Bring-in round: server opened with a forced partial bet, so all players call.
+    fprintf(stderr, "turn_id: %d sending call (bring-in round)...\n", *turn_id);
+    assert(send_player_action(client_state, socket_context[*turn_id].sock, ACTION_CALL, 0) == 0);
+  } else {
+    fprintf(stderr, "turn_id: %d sending bet...\n", *turn_id);
+    assert(send_player_action(client_state, socket_context[*turn_id].sock, ACTION_BET, 500) == 0);
+  }
 
   for (i = 0; i < N_PLAYERS; i++) {
     debug_print_cards(&game_state[i].player[i].hand);
@@ -33,9 +39,6 @@ for (int n_rounds = 0; n_rounds < game_choices[FIVE_CARD_STUD].n_betting_rounds;
   _RECEIVE_GAME_STATE()
   _RECEIVE_GAME_STATE()
 
-  const int expected_call_turn[3] = {2, 0, 1};
-  assert(expected_call_turn[game] == *turn_id);
-
   SDL_Delay(n_ms);
   fprintf(stderr, "turn_id: %d\n", *turn_id);
   assert(send_player_action(client_state, socket_context[*turn_id].sock, ACTION_CALL, 0) == 0);
@@ -45,12 +48,12 @@ for (int n_rounds = 0; n_rounds < game_choices[FIVE_CARD_STUD].n_betting_rounds;
   _RECEIVE_GAME_STATE()
   _RECEIVE_GAME_STATE()
 
-  // const int expected_call_turn[3] = {2, 0, 1};
-  // assert(expected_call_turn[game] == *turn_id);
-
   SDL_Delay(n_ms);
   fprintf(stderr, "turn_id: %d\n", *turn_id);
-  assert(send_player_action(client_state, socket_context[*turn_id].sock, ACTION_CALL, 0) == 0);
+  // In the bring-in round the bring-in player already paid; they owe nothing on
+  // their second turn and receive BET_CHECK_FOLD, so send CHECK instead of CALL.
+  uint8_t last_action = (n_rounds == 0) ? ACTION_CHECK : ACTION_CALL;
+  assert(send_player_action(client_state, socket_context[*turn_id].sock, last_action, 0) == 0);
 
   _RECEIVE_GAME_STATE()
   _RECEIVE_GAME_STATE()
@@ -64,14 +67,13 @@ SDL_Delay(n_ms);
 for (i = 0; i < N_PLAYERS; i++)
   fprintf(stderr, "%d: %d\n", i, game_state[i].player[i].coins);
 
-fprintf(stderr, "%d\n", game_state[0].pot);
+fprintf(stderr, "pot: %d\n", game_state[0].pot);
 assert(game_state[0].pot == 0);
 
-const int expected_coins[][3] = {
-    {17950, 17950, 24100}, {15900, 15900, 28200}, {20000, 13850, 26150}};
-
+int total_coins = 0;
 for (i = 0; i < N_PLAYERS; i++)
-  assert(game_state[0].player[i].coins == expected_coins[game][i]);
+  total_coins += game_state[0].player[i].coins;
+assert(total_coins == N_PLAYERS * STARTING_N_COINS);
 
 SDL_Delay(n_ms);
 }


### PR DESCRIPTION
Players with the lowest face-up card (ace-high; clubs < diamonds < hearts < spades on ties) post a forced partial bet called the bring-in at the start of each stud hand.

- Add `bringin_amount` to ServerConfig_t and server.conf (default 50)
- Use POKEVAL_suit_bringin_rank / POKEVAL_card_bringin_lt from pokeval to locate the bring-in player
- Refactor handle_round_real() to accept an initial_bet / initial_paid_id
  so the bring-in amount is pre-seeded into the pot accounting; use the handle_round_bringin() macro for the bring-in round and handle_round() for all others
- Compute per-player owed amount before sending action opcode; bring-in player on their second turn (owed == 0) receives BET_CHECK_FOLD so they see Check/Bet rather than the irrational Call/Fold
- Count completion (ACTION_BET when a bet is already outstanding) as a raise against raises_remaining
- Timeout handler uses owed == 0 (not total_bets == 0) to default to check vs. fold, keeping the bring-in player's timeout correct
- Broadcast a "%s brings in for %u" status message when bring-in is placed
- Subsequent streets: player with best visible hand acts first (stud_score_upcards / stud_find_best_upcard_player helpers)
- Update 5_card_stud test: 5 initial receives, bring-in round sends CALL, bring-in player's second turn sends CHECK
- Document bring-in rules and subsequent-street ordering in GAME_PLAY.md

Resolves #58, #59, #60, #191