### PR TITLE
bugfix: Show clear error on protocol version mismatch

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@
     exchange button, timeout setting (wild_exchange_timeout_ms), network
     message (MSG_WILD_REPLACEMENT), and server-side exchange logic
   * bugfix: Three busy-waits, high-cpu server usage
+  * bugfix: Show clear error on protocol version mismatch
   * Update docker-compose.yml to use DC_PASSWORD and extra arguments when running
     the server
   * Bump GAME_PROTOCOL_VERSION from 7 to 8

--- a/src/client.c
+++ b/src/client.c
@@ -78,7 +78,23 @@ static int send_protocol_header(TCPsocket sock) {
   snprintf(hdr.magic, sizeof(hdr.magic), "%s", GAME_PROTOCOL_MAGIC);
   hdr.version = SDL_SwapBE16(GAME_PROTOCOL_VERSION);
 
-  return send_all_tcp(sock, &hdr, sizeof(hdr));
+  if (send_all_tcp(sock, &hdr, sizeof(hdr)) != 0)
+    return -1;
+
+  uint8_t response;
+  if (recv_all_tcp(sock, &response, sizeof(response)) <= 0) {
+    fprintf(stderr, "Protocol version mismatch or server closed connection\n");
+    return -1;
+  }
+  if (response != 0) {
+    fprintf(stderr,
+            "Server rejected connection: protocol version mismatch "
+            "(client version: %d)\n",
+            GAME_PROTOCOL_VERSION);
+    return -1;
+  }
+
+  return 0;
 }
 
 static void ma_sound_start_wrap(ma_sound *pSound, const char *file, const int line) {
@@ -2517,10 +2533,8 @@ bool get_socket_context_and_run_client(PlayerConfig_t *player_config, const CliA
   if (SDLNet_TCP_AddSocket(socket_context.set, sock) == -1)
     fputs("Socket set full\n", stderr);
 
-  if (send_protocol_header(sock) != 0) {
-    fputs("Failed to send protocol\n", stderr);
+  if (send_protocol_header(sock) != 0)
     goto cleanup;
-  }
 
   if (!test_mode) {
     const char *env_pw = getenv("DC_PASSWORD");

--- a/src/server.c
+++ b/src/server.c
@@ -1557,6 +1557,14 @@ static int recv_and_validate_protocol_header(TCPsocket sock) {
   uint32_t version = SDL_SwapBE16(hdr.version);
   if (version != GAME_PROTOCOL_VERSION) {
     fprintf(stderr, "Unsupported protocol version: %u\n", version);
+    uint8_t nack = 1;
+    send_all_tcp(sock, &nack, sizeof(nack)); // best-effort; we're closing anyway
+    return -1;
+  }
+
+  uint8_t ack = 0;
+  if (send_all_tcp(sock, &ack, sizeof(ack)) != 0) {
+    fprintf(stderr, "Failed to send protocol ACK\n");
     return -1;
   }
 


### PR DESCRIPTION
Previously the server closed the connection without sending anything back on version mismatch, causing the client to print a confusing cascade of errors (Failed to receive nonce, Authentication attempt failed, etc.).

Server now sends a 1-byte ACK (0) on success or NACK (1) on version mismatch. Client reads the response immediately after sending its header and prints a single descriptive message before bailing out.