### PR TITLE
ci: switch to vcpkg manifest mode with pinned baseline

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -26,11 +26,9 @@ jobs:
       id: cache-vcpkg
       uses: actions/cache@v5
       with:
-        path: |
-          C:\vcpkg\installed\x64-windows-static-md
-          C:\vcpkg\installed\vcpkg
-        key: vcpkg-installed-x64-windows-static-md-${{ hashFiles('.github/workflows/msvc.yml') }}
-        restore-keys: vcpkg-installed-x64-windows-static-md-
+        path: ${{ github.workspace }}\vcpkg_installed
+        key: vcpkg-x64-windows-static-md-${{ hashFiles('vcpkg.json', 'vcpkg-triplets/*.cmake') }}
+        restore-keys: vcpkg-x64-windows-static-md-
 
     - name: Set up MSVC environment
       uses: ilammy/msvc-dev-cmd@v1
@@ -43,20 +41,12 @@ jobs:
     - name: Install dependencies via vcpkg
       if: steps.cache-vcpkg.outputs.cache-hit != 'true'
       run: |
-        $env:VCPKG_ROOT = ""
-        vcpkg install `
-          --overlay-triplets=vcpkg-triplets `
-          sdl2:x64-windows-static-md `
-          sdl2-image:x64-windows-static-md `
-          sdl2-ttf:x64-windows-static-md `
-          sdl2-net:x64-windows-static-md `
-          libsodium:x64-windows-static-md `
-          protobuf-c:x64-windows-static-md
+        vcpkg install --triplet x64-windows-static-md --overlay-triplets=vcpkg-triplets
 
     - name: Meson setup
       run: |
-        $vcpkg_prefix = "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows-static-md"
-        $env:PKG_CONFIG = "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\tools\pkgconf\pkgconf.exe"
+        $vcpkg_prefix = "${{ github.workspace }}\vcpkg_installed\x64-windows-static-md"
+        $env:PKG_CONFIG = "${{ github.workspace }}\vcpkg_installed\x64-windows\tools\pkgconf\pkgconf.exe"
         $env:PKG_CONFIG_PATH = "$vcpkg_prefix\lib\pkgconfig"
         meson setup _build -Db_sanitize=none -Dsodium=enabled "-Dcmake_prefix_path=$vcpkg_prefix"
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "dealers-choice",
+  "builtin-baseline": "77df67cfff9c12ccfdb52284e07c87c75092f723",
+  "dependencies": [
+    "libsodium",
+    "protobuf-c",
+    "sdl2",
+    "sdl2-image",
+    "sdl2-net",
+    "sdl2-ttf"
+  ]
+}


### PR DESCRIPTION
Adds vcpkg.json with builtin-baseline pinned to the vcpkg commit shipped with the windows-2025 runner image (20260405.77). Cache key is now stable, keyed on vcpkg.json and triplet files rather than the workflow file, so it only invalidates when dependencies change.