### PR TITLE
Fix 6/7-card stud wild eval and winning card highlight

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -654,7 +654,8 @@ static void create_card_context(CardWidget_t card_context[MAX_PLAYERS][MAX_HAND_
  * Community cards are marked on every player's context; layout_board_cards has
  * already set is_null=true on non-board player slots, so they won't render. */
 static void mark_winning_cards(CardWidget_t card_context[MAX_PLAYERS][MAX_HAND_SIZE],
-                               Player_t *players_array, const GameChoice_t *game_choice) {
+                               Player_t *players_array, const GameChoice_t *game_choice,
+                               bool deuces_wild) {
   if (!game_choice)
     return;
 
@@ -671,10 +672,21 @@ static void mark_winning_cards(CardWidget_t card_context[MAX_PLAYERS][MAX_HAND_S
       continue;
 
     if (!is_community) {
-      // Server sorted the best 5 into positions 0-4; null beyond that
+      /* Find the best 5-card hand from however many cards are held (may be
+       * 5, 6, or 7 for stud games) and mark only those cards as winning. */
+      POKEVAL_Hand_5 best = deuces_wild
+                                ? POKEVAL_hand5_from_hand7_wild(&players_array[p].hand, DH_CARD_TWO)
+                                : POKEVAL_hand5_from_hand7(&players_array[p].hand);
       for (int c = 0; c < MAX_HAND_SIZE; c++) {
-        if (!card_context[p][c].is_null && !card_context[p][c].is_back)
-          card_context[p][c].is_winning = true;
+        DH_Card card = players_array[p].hand.card[c];
+        if (DH_is_card_null(card) || DH_is_card_back(card))
+          continue;
+        for (int b = 0; b < POKEVAL_HAND_SIZE; b++) {
+          if (card.face_val == best.card[b].face_val && card.suit == best.card[b].suit) {
+            card_context[p][c].is_winning = true;
+            break;
+          }
+        }
       }
       continue;
     }
@@ -1222,6 +1234,7 @@ static bool handle_game_logic(const PlayerConfig_t *player_config, SocketContext
 
   int running = 1;
   bool cards_created = false;
+  bool winner_highlighted = false;
 
   Player_t *players_array = game_state->player;
   Player_t *turn = NULL;
@@ -1285,8 +1298,14 @@ static bool handle_game_logic(const PlayerConfig_t *player_config, SocketContext
     // printf("%d\n", __LINE__);
     if (recv_status == RECV_ERROR)
       running = false;
-    else if (recv_status == RECV_SUCCESS)
-      cards_created = false;
+    else if (recv_status == RECV_SUCCESS) {
+      if (!game_state->winner_declared) {
+        cards_created = false;
+        winner_highlighted = false;
+      } else if (!winner_highlighted) {
+        cards_created = false;
+      }
+    }
 
     if (game_state->at_menu)
       break;
@@ -1389,8 +1408,11 @@ static bool handle_game_logic(const PlayerConfig_t *player_config, SocketContext
         if (community_start > 0)
           layout_board_cards(card_context, starting_turn->id, player_pos, community_start);
       }
-      if (game_state->winner_declared)
-        mark_winning_cards(card_context, game_state->player, client_state.game_choice);
+      if (game_state->winner_declared) {
+        mark_winning_cards(card_context, game_state->player, client_state.game_choice,
+                           client_state.deuces_wild);
+        winner_highlighted = true;
+      }
       cards_created = true;
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -524,8 +524,13 @@ static void server_handle_raise(GameState_t *game_state, uint32_t *total_paid,
   game_state->raises_remaining--;
 }
 
-static void handle_sort_hand(POKEVAL_Hand_9 *real_hand, const bool is_lowball) {
-  POKEVAL_Hand_5 tmp_hand = POKEVAL_hand5_from_hand7(real_hand);
+static void handle_sort_hand(POKEVAL_Hand_9 *real_hand, const bool is_lowball,
+                             const bool deuces_wild) {
+  /* When deuces are wild, select the best 5-card hand using the wild-aware
+   * evaluator so that a 2 is never dropped in favour of a higher non-wild
+   * kicker when picking from a 6- or 7-card stud hand. */
+  POKEVAL_Hand_5 tmp_hand = deuces_wild ? POKEVAL_hand5_from_hand7_wild(real_hand, DH_CARD_TWO)
+                                        : POKEVAL_hand5_from_hand7(real_hand);
   if (!is_lowball)
     POKEVAL_sort_hand(&tmp_hand);
   else
@@ -606,7 +611,8 @@ static ELoop_t handle_draw(ArgsBroadcastGameState_t *args, TCPsocket sock, const
 
   if (req.discard_count > 0) {
     handle_sort_hand(&args->real_hand->player[id],
-                     args->game_type == game_choices[CALIFORNIA_LOWBALL].game_type);
+                     args->game_type == game_choices[CALIFORNIA_LOWBALL].game_type,
+                     args->deuces_wild);
     send_new_hand(sock, &args->real_hand->player[id], MAX_HAND_SIZE);
   }
 
@@ -644,15 +650,9 @@ static void determine_winner(ArgsBroadcastGameState_t *args, RoundResults *resul
 
   Player_t *ptr = *args->starting_turn;
 
-  ptr = *args->starting_turn;
-  if (args->game_type != game_choices[TEXAS_HOLDEM].game_type &&
-      args->game_type != game_choices[OMAHA].game_type) {
-    do {
-      handle_sort_hand(&args->real_hand->player[ptr->id],
-                       args->game_type == game_choices[CALIFORNIA_LOWBALL].game_type);
-      ptr = get_next_player(args->game_state->player, ptr->id);
-    } while (ptr && ptr != *args->starting_turn);
-  }
+  /* Do not truncate or sort hands here — clients display all dealt cards and
+   * identify the best 5 themselves.  POKEVAL_compare_hands* already handles
+   * 6- and 7-card hands via hand5_from_hand7 internally. */
 
   // When set to true, the opponents` cards will be revealed to all the players the next
   // time broadcast_game_state is called
@@ -1118,7 +1118,8 @@ void game_five_card_draw(GAME_ARGS) {
   Player_t *turn = *args->starting_turn;
   do {
     handle_sort_hand(&args->real_hand->player[turn->id],
-                     args->game_type == game_choices[CALIFORNIA_LOWBALL].game_type);
+                     args->game_type == game_choices[CALIFORNIA_LOWBALL].game_type,
+                     args->deuces_wild);
     turn = get_next_player(players_array, turn->id);
   } while (turn && turn != *args->starting_turn);
 

--- a/src/widgets/card.c
+++ b/src/widgets/card.c
@@ -488,17 +488,30 @@ static void card_widget_render(UIWidget_t *w) {
   SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
   SDL_RenderFillRect(renderer, &w->rect);
 
-  // Highlight winning cards: gold tint + thick inset border so the indicator
-  // is visible to people who have difficulty perceiving color alone.
+  // Highlight winning cards: gold tint + 3D bevel border (5× thickness).
   if (cw->is_winning) {
     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
     SDL_SetRenderDrawColor(renderer, 255, 200, 0, 110); // translucent gold fill
     SDL_RenderFillRect(renderer, &w->rect);
     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_NONE);
-    SDL_SetRenderDrawColor(renderer, 220, 160, 0, 255); // solid gold border
-    for (int t = 0; t < 3; t++) {
-      SDL_Rect border = {w->rect.x + t, w->rect.y + t, w->rect.w - 2 * t, w->rect.h - 2 * t};
-      SDL_RenderDrawRect(renderer, &border);
+
+    /* Raised-bevel effect drawn outside the card rect: bright gold on
+     * top/left edges, dark brown on bottom/right edges.  t=0 is the ring
+     * immediately adjacent to the card boundary; t=B-1 is the outermost. */
+    const int B = 8;
+    for (int t = 0; t < B; t++) {
+      int x1 = w->rect.x - t - 1;
+      int y1 = w->rect.y - t - 1;
+      int x2 = w->rect.x + w->rect.w + t;
+      int y2 = w->rect.y + w->rect.h + t;
+
+      SDL_SetRenderDrawColor(renderer, 255, 215, 0, 255); // bright gold — highlight
+      SDL_RenderDrawLine(renderer, x1, y1, x2, y1);       // top
+      SDL_RenderDrawLine(renderer, x1, y1, x1, y2);       // left
+
+      SDL_SetRenderDrawColor(renderer, 130, 80, 0, 255); // dark brown — shadow
+      SDL_RenderDrawLine(renderer, x1, y2, x2, y2);      // bottom
+      SDL_RenderDrawLine(renderer, x2, y1, x2, y2);      // right
     }
   }
 


### PR DESCRIPTION
- handle_sort_hand: pass deuces_wild so wild hands use POKEVAL_hand5_from_hand7_wild instead of discarding the wild card
- determine_winner: stop truncating 6/7-card hands before broadcast; clients display all dealt cards at showdown
- client: use winner_highlighted flag so card context is rebuilt exactly once when winner is declared, preserving cards and applying highlights
- mark_winning_cards: identify best-5 client-side via hand5_from_hand7 (or wild variant) to highlight only the winning cards
- card rendering: draw the 3D bevel outside the card boundary so the card face is fully visible; bright gold top/left, dark brown bottom/right