### PR TITLE
config: derive entry counts from sentinel-terminated arrays

### DIFF
--- a/src/dc_config.c
+++ b/src/dc_config.c
@@ -38,7 +38,7 @@
 #include "dc_config.h"
 #include "util.h"
 
-const ConfigEntry player_config_entries[PLAYER_CONFIG_ENTRY_COUNT] = {
+const ConfigEntry player_config_entries[] = {
     {"nick", CFG_TYPE_STRING, "New Player", offsetof(PlayerConfig_t, nick),
      sizeof(((PlayerConfig_t *)0)->nick)},
     {"host", CFG_TYPE_STRING, "127.0.0.1", offsetof(PlayerConfig_t, host),
@@ -52,9 +52,10 @@ const ConfigEntry player_config_entries[PLAYER_CONFIG_ENTRY_COUNT] = {
     {"connect.attempts", CFG_TYPE_UINT8, "6", offsetof(PlayerConfig_t, connect_attempts),
      sizeof(uint8_t)},
     {"password", CFG_TYPE_STRING, "", offsetof(PlayerConfig_t, password),
-     sizeof(((PlayerConfig_t *)0)->password)}};
+     sizeof(((PlayerConfig_t *)0)->password)},
+    {0}};
 
-const ConfigEntry server_config_entries[SERVER_CONFIG_ENTRY_COUNT] = {
+const ConfigEntry server_config_entries[] = {
     {"bind_address", CFG_TYPE_STRING, "127.0.0.1", offsetof(ServerConfig_t, bind_address),
      sizeof(((ServerConfig_t *)0)->bind_address)},
     {"port", CFG_TYPE_UINT16, DEFAULT_PORT, offsetof(ServerConfig_t, port), sizeof(uint16_t)},
@@ -77,12 +78,16 @@ const ConfigEntry server_config_entries[SERVER_CONFIG_ENTRY_COUNT] = {
     {"max_connections_per_minute", CFG_TYPE_UINT32, "10",
      offsetof(ServerConfig_t, max_connections_per_minute), sizeof(uint32_t)},
     {"max_connections_per_ip", CFG_TYPE_UINT32, "0",
-     offsetof(ServerConfig_t, max_connections_per_ip), sizeof(uint32_t)}};
+     offsetof(ServerConfig_t, max_connections_per_ip), sizeof(uint32_t)},
+    {0}};
 
-_Static_assert(ARRAY_SIZE(player_config_entries) == PLAYER_CONFIG_ENTRY_COUNT,
-               "PLAYER_CONFIG_ENTRY_COUNT is out of sync");
-_Static_assert(ARRAY_SIZE(server_config_entries) == SERVER_CONFIG_ENTRY_COUNT,
-               "SERVER_CONFIG_ENTRY_COUNT is out of sync");
+const size_t player_config_entry_count = ARRAY_SIZE(player_config_entries) - 1;
+const size_t server_config_entry_count = ARRAY_SIZE(server_config_entries) - 1;
+
+_Static_assert(ARRAY_SIZE(player_config_entries) - 1 <= MAX_PLAYER_CONFIG_ENTRIES,
+               "Too many player config entries; increase MAX_PLAYER_CONFIG_ENTRIES");
+_Static_assert(ARRAY_SIZE(server_config_entries) - 1 <= MAX_SERVER_CONFIG_ENTRIES,
+               "Too many server config entries; increase MAX_SERVER_CONFIG_ENTRIES");
 
 #define CFG_SET_SIGNED(TYPE, MIN, MAX)                                                             \
   do {                                                                                             \
@@ -212,7 +217,7 @@ ServerConfig_t get_server_config(Path_t *path, const CliArgs_t *cli_args) {
     exit(EXIT_FAILURE);
 
   // Track which keys were found
-  bool found_keys[server_config_entry_count];
+  bool found_keys[MAX_SERVER_CONFIG_ENTRIES];
   memset(found_keys, 0, sizeof(found_keys));
 
   bool found_bet_amounts = false;
@@ -326,7 +331,7 @@ PlayerConfig_t get_player_config(void) {
     }
   } else {
     // Track which keys were found
-    bool found_keys[player_config_entry_count];
+    bool found_keys[MAX_PLAYER_CONFIG_ENTRIES];
     memset(found_keys, 0, sizeof(found_keys));
 
     while (cfg_node) {

--- a/src/dc_config.h
+++ b/src/dc_config.h
@@ -82,14 +82,14 @@ typedef struct {
   size_t size;               // Size of the target field
 } ConfigEntry;
 
-#define PLAYER_CONFIG_ENTRY_COUNT 8
-#define SERVER_CONFIG_ENTRY_COUNT 13
+#define MAX_PLAYER_CONFIG_ENTRIES 16
+#define MAX_SERVER_CONFIG_ENTRIES 32
 
-extern const ConfigEntry player_config_entries[PLAYER_CONFIG_ENTRY_COUNT];
-extern const ConfigEntry server_config_entries[SERVER_CONFIG_ENTRY_COUNT];
+extern const ConfigEntry player_config_entries[];
+extern const ConfigEntry server_config_entries[];
 
-enum { player_config_entry_count = PLAYER_CONFIG_ENTRY_COUNT };
-enum { server_config_entry_count = SERVER_CONFIG_ENTRY_COUNT };
+extern const size_t player_config_entry_count;
+extern const size_t server_config_entry_count;
 
 ServerConfig_t get_server_config(Path_t *path, const CliArgs_t *cli_args);
 

--- a/src/main.c
+++ b/src/main.c
@@ -357,8 +357,8 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
     ui_register(&reg, &turn_cb->base);
 
   /* Text inputs for displayed non-bool entries (skip host=1, port=2) */
-  char init_str[player_config_entry_count][MAX_INPUT_LENGTH];
-  InputWidget_t *inputs[player_config_entry_count];
+  char init_str[MAX_PLAYER_CONFIG_ENTRIES][MAX_INPUT_LENGTH];
+  InputWidget_t *inputs[MAX_PLAYER_CONFIG_ENTRIES];
   size_t n_text_inputs = 0;
   size_t display_pos = 0;
   for (size_t i = 0; i < player_config_entry_count; i++) {
@@ -418,7 +418,7 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
   }
 
   /* focused_slot indexes only the text input slots (skips host, port, bool_idx) */
-  size_t text_input_indices[player_config_entry_count];
+  size_t text_input_indices[MAX_PLAYER_CONFIG_ENTRIES];
   size_t n_ti = 0;
   for (size_t i = 0; i < player_config_entry_count; i++)
     if (i != bool_idx && i != 1 && i != 2)
@@ -463,7 +463,7 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
   if (tw_settings_title)
     ui_widget_place(&tw_settings_title->base, title_rect.x, title_rect.y);
 
-  TextWidget_t *tw_labels[player_config_entry_count];
+  TextWidget_t *tw_labels[MAX_PLAYER_CONFIG_ENTRIES];
   for (size_t i = 0; i < player_config_entry_count; i++)
     tw_labels[i] = NULL;
   {


### PR DESCRIPTION
Remove PLAYER_CONFIG_ENTRY_COUNT / SERVER_CONFIG_ENTRY_COUNT; counts are now computed from ARRAY_SIZE on NULL-sentinel-terminated arrays. Fixed-size arrays use MAX_PLAYER_CONFIG_ENTRIES / MAX_SERVER_CONFIG_ENTRIES as generous upper bounds; _Static_assert breaks the build if either array exceeds them.