### PR TITLE
Add rule to include subprojects/pcg

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -85,7 +85,7 @@ jobs:
 
     - name: Dist test
       if: ${{ contains(matrix.name, 'dist-test') }}
-      run: meson dist -C _build
+      run: meson dist --include-subprojects -C _build
 
     - name: Install test
       run: meson install --destdir=install_test -C _build

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ subprojects/**
 !subprojects/miniaudio/
 !subprojects/miniaudio/**
 
+!subprojects/pcg/
+!subprojects/pcg/**
+
 # Allow traversal into packagefiles
 !subprojects/packagefiles/
 !subprojects/packagefiles/**

--- a/subprojects/pcg/.gitignore
+++ b/subprojects/pcg/.gitignore
@@ -1,0 +1,37 @@
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Debug Information
+*.dSYM
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Actual Project Executables
+
+pcg32-demo
+pcg32-global-demo
+pcg32x2-demo

--- a/subprojects/pcg/LICENSE.txt
+++ b/subprojects/pcg/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/subprojects/pcg/Makefile
+++ b/subprojects/pcg/Makefile
@@ -1,0 +1,38 @@
+# 
+# PCG Random Number Generation for C.
+# 
+# Copyright 2014 Melissa O'Neill <oneill@pcg-random.org>
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# For additional information about the PCG random number generation scheme,
+# including its license and other licensing options, visit
+# 
+#     http://www.pcg-random.org
+#
+
+TARGETS = pcg32-global-demo pcg32-demo pcg32x2-demo
+
+all: $(TARGETS)
+
+clean:
+	rm -f *.o $(TARGETS)
+
+pcg32-global-demo: pcg32-global-demo.o pcg_basic.o
+pcg32-demo: pcg32-demo.o pcg_basic.o
+pcg32x2-demo: pcg32x2-demo.o pcg_basic.o
+
+pcg_basic.o: pcg_basic.c pcg_basic.h
+pcg32-demo.o: pcg32-demo.c pcg_basic.h
+pcg32-global-demo.o: pcg32-global-demo.c pcg_basic.h
+pcg32x2-demo.o: pcg32x2-demo.c pcg_basic.h

--- a/subprojects/pcg/README.md
+++ b/subprojects/pcg/README.md
@@ -1,0 +1,55 @@
+# PCG Random Number Generation, Minimal C Edition
+
+[PCG-Random website]: http://www.pcg-random.org
+
+This code provides a minimal implementation of one member of the PCG family
+of random number generators, which are fast, statistically excellent,
+and offer a number of useful features.
+
+Full details can be found at the [PCG-Random website].  This version
+of the code provides a single family member and skips some useful features
+(such as jump-ahead/jump-back) -- if you want a more full-featured library, 
+you may prefer the full version of the C library, or for all features,
+the C++ library.
+
+## Documentation and Examples
+
+Visit [PCG-Random website] for information on how to use this library, or look
+at the sample code -- hopefully it should be fairly self explanatory.
+
+## Building
+
+There is no library to build.  Just use the code.  You can however build the
+three demo programs.
+
+The code is written in C89-style C with no significant platform dependencies.
+On a Unix-style system (e.g., Linux, Mac OS X), or any system with `make`,
+you should be able to just type type
+
+    make
+
+Almost all the real code is in `pcg_basic.c`, with type and function
+declarations in `pcg_basic.h`.  
+
+On other systems, it should be straightforward to build.  For example, you
+even run the code directly using the tinycc compiler, using
+
+    cat pcg_basic.c pcg32-demo.c | tcc -run
+
+## Testing
+
+This command will build the three provided demo programs, `pcg32-global-demo`
+(which uses the global rng), `pcg32-demo` (which uses a local generator), and
+pcg32x2-demo (which gangs together two generators, showing the usefulness of
+creating multiple generators).
+
+To run the demos using a fixed seed (same output every time), run
+
+    ./pcg32-demo
+    
+To produce different output, run
+
+    ./pcg32-demo -r
+
+You can also pass an integer count to specify how may rounds of output you
+would like.

--- a/subprojects/pcg/meson.build
+++ b/subprojects/pcg/meson.build
@@ -1,0 +1,26 @@
+project(
+    'pcg',
+    'c',
+    version: '0.9',
+    meson_version: '>= 0.56.0',
+    default_options: ['warning_level=3', 'c_std=c99'],
+)
+
+cc = meson.get_compiler('c')
+
+if cc.get_id() != 'msvc'
+  extra_flags = [
+      '-fno-common',
+      '-fstack-protector-strong',
+      '-Wformat-security',
+      '-Wshadow',
+      '-Wstrict-overflow=5',
+      '-Werror=odr',
+      '-Werror=strict-aliasing',
+  ]
+  add_project_arguments(cc.get_supported_arguments(extra_flags), language: 'c')
+endif
+
+_pcg = static_library('pcg', 'pcg_basic.c')
+
+pcg_dep = declare_dependency(link_with: _pcg, include_directories: '.')

--- a/subprojects/pcg/pcg32-demo.c
+++ b/subprojects/pcg/pcg32-demo.c
@@ -1,0 +1,143 @@
+/*
+ * PCG Random Number Generation for C.
+ *
+ * Copyright 2014 Melissa O'Neill <oneill@pcg-random.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For additional information about the PCG random number generation scheme,
+ * including its license and other licensing options, visit
+ *
+ *     http://www.pcg-random.org
+ */
+
+/*
+ * This file was mechanically generated from tests/check-pcg32.c
+ */
+
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <time.h>
+#include <string.h>
+
+#include "pcg_basic.h"
+
+int main(int argc, char** argv)
+{
+    // Read command-line options
+
+    int rounds = 5;
+    bool nondeterministic_seed = false;
+    int round, i;
+
+    ++argv;
+    --argc;
+    if (argc > 0 && strcmp(argv[0], "-r") == 0) {
+        nondeterministic_seed = true;
+        ++argv;
+        --argc;
+    }
+    if (argc > 0) {
+        rounds = atoi(argv[0]);
+    }
+
+    // In this version of the code, we'll use a local rng, rather than the
+    // global one.
+
+    pcg32_random_t rng;
+
+    // You should *always* seed the RNG.  The usual time to do it is the
+    // point in time when you create RNG (typically at the beginning of the
+    // program).
+    //
+    // pcg32_srandom_r takes two 64-bit constants (the initial state, and the
+    // rng sequence selector; rngs with different sequence selectors will
+    // *never* have random sequences that coincide, at all) - the code below
+    // shows three possible ways to do so.
+
+    if (nondeterministic_seed) {
+        // Seed with external entropy -- the time and some program addresses
+        // (which will actually be somewhat random on most modern systems).
+        // A better solution, entropy_getbytes, using /dev/random, is provided
+        // in the full library.
+        
+        pcg32_srandom_r(&rng, time(NULL) ^ (intptr_t)&printf, 
+			      (intptr_t)&rounds);
+    } else {
+        // Seed with a fixed constant
+
+        pcg32_srandom_r(&rng, 42u, 54u);
+    }
+
+    printf("pcg32_random_r:\n"
+           "      -  result:      32-bit unsigned int (uint32_t)\n"
+           "      -  period:      2^64   (* 2^63 streams)\n"
+           "      -  state type:  pcg32_random_t (%zu bytes)\n"
+           "      -  output func: XSH-RR\n"
+           "\n",
+           sizeof(pcg32_random_t));
+
+    for (round = 1; round <= rounds; ++round) {
+        printf("Round %d:\n", round);
+        /* Make some 32-bit numbers */
+        printf("  32bit:");
+        for (i = 0; i < 6; ++i)
+            printf(" 0x%08x", pcg32_random_r(&rng));
+        printf("\n");
+
+        /* Toss some coins */
+        printf("  Coins: ");
+        for (i = 0; i < 65; ++i)
+            printf("%c", pcg32_boundedrand_r(&rng, 2) ? 'H' : 'T');
+        printf("\n");
+
+        /* Roll some dice */
+        printf("  Rolls:");
+        for (i = 0; i < 33; ++i) {
+            printf(" %d", (int)pcg32_boundedrand_r(&rng, 6) + 1);
+        }
+        printf("\n");
+
+        /* Deal some cards */
+        enum { SUITS = 4, NUMBERS = 13, CARDS = 52 };
+        char cards[CARDS];
+
+        for (i = 0; i < CARDS; ++i)
+            cards[i] = i;
+
+        for (i = CARDS; i > 1; --i) {
+            int chosen = pcg32_boundedrand_r(&rng, i);
+            char card = cards[chosen];
+            cards[chosen] = cards[i - 1];
+            cards[i - 1] = card;
+        }
+
+        printf("  Cards:");
+        static const char number[] = {'A', '2', '3', '4', '5', '6', '7',
+                                      '8', '9', 'T', 'J', 'Q', 'K'};
+        static const char suit[] = {'h', 'c', 'd', 's'};
+        for (i = 0; i < CARDS; ++i) {
+            printf(" %c%c", number[cards[i] / SUITS], suit[cards[i] % SUITS]);
+            if ((i + 1) % 22 == 0)
+                printf("\n\t");
+        }
+        printf("\n");
+
+        printf("\n");
+    }
+
+    return 0;
+}

--- a/subprojects/pcg/pcg32-global-demo.c
+++ b/subprojects/pcg/pcg32-global-demo.c
@@ -1,0 +1,139 @@
+/*
+ * PCG Random Number Generation for C.
+ *
+ * Copyright 2014 Melissa O'Neill <oneill@pcg-random.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For additional information about the PCG random number generation scheme,
+ * including its license and other licensing options, visit
+ *
+ *     http://www.pcg-random.org
+ */
+
+/*
+ * This file was mechanically generated from tests/check-pcg32.c
+ */
+
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <time.h>
+#include <string.h>
+
+#include "pcg_basic.h"
+
+int main(int argc, char** argv)
+{
+    // Read command-line options
+
+    int rounds = 5;
+    bool nondeterministic_seed = false;
+    int round, i;
+
+    ++argv;
+    --argc;
+    if (argc > 0 && strcmp(argv[0], "-r") == 0) {
+        nondeterministic_seed = true;
+        ++argv;
+        --argc;
+    }
+    if (argc > 0) {
+        rounds = atoi(argv[0]);
+    }
+
+    // In this version of the code, we'll use the global rng, rather than a
+    // local one.
+
+    // You should *always* seed the RNG.  The usual time to do it is the
+    // point in time when you create RNG (typically at the beginning of the
+    // program).
+    //
+    // pcg32_srandom_r takes two 64-bit constants (the initial state, and the
+    // rng sequence selector; rngs with different sequence selectors will
+    // *never* have random sequences that coincide, at all) - the code below
+    // shows three possible ways to do so.
+
+    if (nondeterministic_seed) {
+        // Seed with external entropy -- the time and some program addresses
+        // (which will actually be somewhat random on most modern systems).
+        // A better solution, entropy_getbytes, using /dev/random, is provided
+        // in the full library.
+        
+        pcg32_srandom(time(NULL) ^ (intptr_t)&printf, (intptr_t)&rounds);
+    } else {
+        // Seed with a fixed constant
+
+        pcg32_srandom(42u, 54u);
+    }
+
+    printf("pcg32_random:\n"
+           "      -  result:      32-bit unsigned int (uint32_t)\n"
+           "      -  period:      2^64   (* 2^63 streams)\n"
+           "      -  state type:  N/A (private global)\n"
+           "      -  output func: XSH-RR\n"
+           "\n");
+
+    for (round = 1; round <= rounds; ++round) {
+        printf("Round %d:\n", round);
+        /* Make some 32-bit numbers */
+        printf("  32bit:");
+        for (i = 0; i < 6; ++i)
+            printf(" 0x%08x", pcg32_random());
+        printf("\n");
+
+        /* Toss some coins */
+        printf("  Coins: ");
+        for (i = 0; i < 65; ++i)
+            printf("%c", pcg32_boundedrand(2) ? 'H' : 'T');
+        printf("\n");
+
+        /* Roll some dice */
+        printf("  Rolls:");
+        for (i = 0; i < 33; ++i) {
+            printf(" %d", (int)pcg32_boundedrand(6) + 1);
+        }
+        printf("\n");
+
+        /* Deal some cards */
+        enum { SUITS = 4, NUMBERS = 13, CARDS = 52 };
+        char cards[CARDS];
+
+        for (i = 0; i < CARDS; ++i)
+            cards[i] = i;
+
+        for (i = CARDS; i > 1; --i) {
+            int chosen = pcg32_boundedrand(i);
+            char card = cards[chosen];
+            cards[chosen] = cards[i - 1];
+            cards[i - 1] = card;
+        }
+
+        printf("  Cards:");
+        static const char number[] = {'A', '2', '3', '4', '5', '6', '7',
+                                      '8', '9', 'T', 'J', 'Q', 'K'};
+        static const char suit[] = {'h', 'c', 'd', 's'};
+        for (i = 0; i < CARDS; ++i) {
+            printf(" %c%c", number[cards[i] / SUITS], suit[cards[i] % SUITS]);
+            if ((i + 1) % 22 == 0)
+                printf("\n\t");
+        }
+        printf("\n");
+
+        printf("\n");
+    }
+
+    return 0;
+}

--- a/subprojects/pcg/pcg32x2-demo.c
+++ b/subprojects/pcg/pcg32x2-demo.c
@@ -1,0 +1,201 @@
+/*
+ * PCG Random Number Generation for C.
+ *
+ * Copyright 2014 Melissa O'Neill <oneill@pcg-random.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For additional information about the PCG random number generation scheme,
+ * including its license and other licensing options, visit
+ *
+ *     http://www.pcg-random.org
+ */
+
+/*
+ * This file was mechanically generated from tests/check-pcg32.c
+ */
+
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <time.h>
+#include <string.h>
+
+#include "pcg_basic.h"
+
+/*
+ * This code shows how you can cope if you're on a 32-bit platform (or a
+ * 64-bit platform with a mediocre compiler) that doesn't support 128-bit math,
+ * or if you're using the basic version of the library which only provides
+ * 32-bit generation.
+ *
+ * Here we build a 64-bit generator by tying together two 32-bit generators.
+ * Note that we can do this because we set up the generators so that each
+ * 32-bit generator has a *totally different* different output sequence
+ * -- if you tied together two identical generators, that wouldn't be nearly
+ * as good.
+ *
+ * For simplicity, we keep the period fixed at 2^64.  The state space is
+ * approximately 2^254 (actually  2^64 * 2^64 * 2^63 * (2^63 - 1)), which
+ * is huge.
+ */
+
+typedef struct {
+    pcg32_random_t gen[2];
+} pcg32x2_random_t;
+
+void pcg32x2_srandom_r(pcg32x2_random_t* rng, uint64_t seed1, uint64_t seed2,
+                       uint64_t seq1,  uint64_t seq2)
+{
+    uint64_t mask = ~0ull >> 1;
+    // The stream for each of the two generators *must* be distinct
+    if ((seq1 & mask) == (seq2 & mask)) 
+        seq2 = ~seq2;
+    pcg32_srandom_r(rng->gen,   seed1, seq1);
+    pcg32_srandom_r(rng->gen+1, seed2, seq2);
+}
+
+uint64_t pcg32x2_random_r(pcg32x2_random_t* rng)
+{
+    return ((uint64_t)(pcg32_random_r(rng->gen)) << 32)
+           | pcg32_random_r(rng->gen+1);
+}
+
+/* See other definitons of ..._boundedrand_r for an explanation of this code. */
+
+uint64_t pcg32x2_boundedrand_r(pcg32x2_random_t* rng, uint64_t bound)
+{
+    uint64_t threshold = -bound % bound;
+    for (;;) {
+        uint64_t r = pcg32x2_random_r(rng);
+        if (r >= threshold)
+            return r % bound;
+    }
+}
+
+int dummy_global;
+
+int main(int argc, char** argv)
+{
+    // Read command-line options
+
+    int rounds = 5;
+    bool nondeterministic_seed = false;
+    int round, i;
+
+    ++argv;
+    --argc;
+    if (argc > 0 && strcmp(argv[0], "-r") == 0) {
+        nondeterministic_seed = true;
+        ++argv;
+        --argc;
+    }
+    if (argc > 0) {
+        rounds = atoi(argv[0]);
+    }
+
+    // In this version of the code, we'll use our custom rng rather than
+    // one of the provided ones.
+
+    pcg32x2_random_t rng;
+
+    // You should *always* seed the RNG.  The usual time to do it is the
+    // point in time when you create RNG (typically at the beginning of the
+    // program).
+    //
+    // pcg32x2_srandom_r takes four 64-bit constants (the initial state, and 
+    // the rng sequence selector; rngs with different sequence selectors will
+    // *never* have random sequences that coincide, at all) - the code below
+    // shows three possible ways to do so.
+
+    if (nondeterministic_seed) {
+        // Seed with external entropy -- the time and some program addresses
+        // (which will actually be somewhat random on most modern systems).
+        // A better solution, entropy_getbytes, using /dev/random, is provided
+        // in the full library.
+        
+        pcg32x2_srandom_r(&rng, time(NULL) ^ (intptr_t)&printf,
+                               ~time(NULL) ^ (intptr_t)&pcg32_random_r,
+                                (intptr_t)&rounds,
+                                (intptr_t)&dummy_global);
+    } else {
+        // Seed with a fixed constant
+
+        pcg32x2_srandom_r(&rng, 42u, 42u, 54u, 54u);
+    }
+
+    printf("pcg32x2_random_r:\n"
+           "      -  result:      64-bit unsigned int (uint64_t)\n"
+           "      -  period:      2^64   (* ~2^126 streams)\n"
+           "      -  state space: ~2^254\n"
+           "      -  state type:  pcg32x2_random_t (%zu bytes)\n"
+           "      -  output func: XSH-RR (x 2)\n"
+           "\n",
+           sizeof(pcg32x2_random_t));
+
+    for (round = 1; round <= rounds; ++round) {
+        printf("Round %d:\n", round);
+        /* Make some 32-bit numbers */
+        printf("  64bit:");
+        for (i = 0; i < 6; ++i) {
+            if (i > 0 && i % 3 == 0)
+                printf("\n\t");
+            printf(" 0x%016llx", pcg32x2_random_r(&rng));
+        }
+        printf("\n");
+
+        /* Toss some coins */
+        printf("  Coins: ");
+        for (i = 0; i < 65; ++i)
+            printf("%c", pcg32x2_boundedrand_r(&rng, 2) ? 'H' : 'T');
+        printf("\n");
+
+        /* Roll some dice */
+        printf("  Rolls:");
+        for (i = 0; i < 33; ++i) {
+            printf(" %d", (int)pcg32x2_boundedrand_r(&rng, 6) + 1);
+        }
+        printf("\n");
+
+        /* Deal some cards */
+        enum { SUITS = 4, NUMBERS = 13, CARDS = 52 };
+        char cards[CARDS];
+
+        for (i = 0; i < CARDS; ++i)
+            cards[i] = i;
+
+        for (i = CARDS; i > 1; --i) {
+            int chosen = pcg32x2_boundedrand_r(&rng, i);
+            char card = cards[chosen];
+            cards[chosen] = cards[i - 1];
+            cards[i - 1] = card;
+        }
+
+        printf("  Cards:");
+        static const char number[] = {'A', '2', '3', '4', '5', '6', '7',
+                                      '8', '9', 'T', 'J', 'Q', 'K'};
+        static const char suit[] = {'h', 'c', 'd', 's'};
+        for (i = 0; i < CARDS; ++i) {
+            printf(" %c%c", number[cards[i] / SUITS], suit[cards[i] % SUITS]);
+            if ((i + 1) % 22 == 0)
+                printf("\n\t");
+        }
+        printf("\n");
+
+        printf("\n");
+    }
+
+    return 0;
+}

--- a/subprojects/pcg/pcg_basic.c
+++ b/subprojects/pcg/pcg_basic.c
@@ -1,0 +1,119 @@
+/*
+ * PCG Random Number Generation for C.
+ *
+ * Copyright 2014 Melissa O'Neill <oneill@pcg-random.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For additional information about the PCG random number generation scheme,
+ * including its license and other licensing options, visit
+ *
+ *       http://www.pcg-random.org
+ */
+
+/* Modified from the original: added explicit casts to suppress MSVC warnings
+ * C4146 (unary minus on unsigned type) and C4244 (uint64_t to uint32_t). */
+
+/*
+ * This code is derived from the full C implementation, which is in turn
+ * derived from the canonical C++ PCG implementation. The C++ version
+ * has many additional features and is preferable if you can use C++ in
+ * your project.
+ */
+
+#include "pcg_basic.h"
+
+// state for global RNGs
+
+static pcg32_random_t pcg32_global = PCG32_INITIALIZER;
+
+// pcg32_srandom(initstate, initseq)
+// pcg32_srandom_r(rng, initstate, initseq):
+//     Seed the rng.  Specified in two parts, state initializer and a
+//     sequence selection constant (a.k.a. stream id)
+
+void pcg32_srandom_r(pcg32_random_t* rng, uint64_t initstate, uint64_t initseq)
+{
+    rng->state = 0U;
+    rng->inc = (initseq << 1u) | 1u;
+    pcg32_random_r(rng);
+    rng->state += initstate;
+    pcg32_random_r(rng);
+}
+
+void pcg32_srandom(uint64_t seed, uint64_t seq)
+{
+    pcg32_srandom_r(&pcg32_global, seed, seq);
+}
+
+// pcg32_random()
+// pcg32_random_r(rng)
+//     Generate a uniformly distributed 32-bit random number
+
+uint32_t pcg32_random_r(pcg32_random_t* rng)
+{
+    uint64_t oldstate = rng->state;
+    rng->state = oldstate * 6364136223846793005ULL + rng->inc;
+    uint32_t xorshifted = (uint32_t)(((oldstate >> 18u) ^ oldstate) >> 27u);
+    uint32_t rot = (uint32_t)(oldstate >> 59u);
+    return (xorshifted >> rot) | (xorshifted << ((0u - rot) & 31u));
+}
+
+uint32_t pcg32_random(void)
+{
+    return pcg32_random_r(&pcg32_global);
+}
+
+
+// pcg32_boundedrand(bound):
+// pcg32_boundedrand_r(rng, bound):
+//     Generate a uniformly distributed number, r, where 0 <= r < bound
+
+uint32_t pcg32_boundedrand_r(pcg32_random_t* rng, uint32_t bound)
+{
+    // To avoid bias, we need to make the range of the RNG a multiple of
+    // bound, which we do by dropping output less than a threshold.
+    // A naive scheme to calculate the threshold would be to do
+    //
+    //     uint32_t threshold = 0x100000000ull % bound;
+    //
+    // but 64-bit div/mod is slower than 32-bit div/mod (especially on
+    // 32-bit platforms).  In essence, we do
+    //
+    //     uint32_t threshold = (0x100000000ull-bound) % bound;
+    //
+    // because this version will calculate the same modulus, but the LHS
+    // value is less than 2^32.
+
+    uint32_t threshold = (0u - bound) % bound;
+
+    // Uniformity guarantees that this loop will terminate.  In practice, it
+    // should usually terminate quickly; on average (assuming all bounds are
+    // equally likely), 82.25% of the time, we can expect it to require just
+    // one iteration.  In the worst case, someone passes a bound of 2^31 + 1
+    // (i.e., 2147483649), which invalidates almost 50% of the range.  In
+    // practice, bounds are typically small and only a tiny amount of the range
+    // is eliminated.
+    for (;;) {
+        uint32_t r = pcg32_random_r(rng);
+        if (r >= threshold)
+            return r % bound;
+    }
+}
+
+
+uint32_t pcg32_boundedrand(uint32_t bound)
+{
+    return pcg32_boundedrand_r(&pcg32_global, bound);
+}
+

--- a/subprojects/pcg/pcg_basic.h
+++ b/subprojects/pcg/pcg_basic.h
@@ -1,0 +1,78 @@
+/*
+ * PCG Random Number Generation for C.
+ *
+ * Copyright 2014 Melissa O'Neill <oneill@pcg-random.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For additional information about the PCG random number generation scheme,
+ * including its license and other licensing options, visit
+ *
+ *     http://www.pcg-random.org
+ */
+
+/*
+ * This code is derived from the full C implementation, which is in turn
+ * derived from the canonical C++ PCG implementation. The C++ version
+ * has many additional features and is preferable if you can use C++ in
+ * your project.
+ */
+
+#ifndef PCG_BASIC_H_INCLUDED
+#define PCG_BASIC_H_INCLUDED 1
+
+#include <inttypes.h>
+
+#if __cplusplus
+extern "C" {
+#endif
+
+struct pcg_state_setseq_64 {    // Internals are *Private*.
+    uint64_t state;             // RNG state.  All values are possible.
+    uint64_t inc;               // Controls which RNG sequence (stream) is
+                                // selected. Must *always* be odd.
+};
+typedef struct pcg_state_setseq_64 pcg32_random_t;
+
+// If you *must* statically initialize it, here's one.
+
+#define PCG32_INITIALIZER   { 0x853c49e6748fea9bULL, 0xda3e39cb94b95bdbULL }
+
+// pcg32_srandom(initstate, initseq)
+// pcg32_srandom_r(rng, initstate, initseq):
+//     Seed the rng.  Specified in two parts, state initializer and a
+//     sequence selection constant (a.k.a. stream id)
+
+void pcg32_srandom(uint64_t initstate, uint64_t initseq);
+void pcg32_srandom_r(pcg32_random_t* rng, uint64_t initstate,
+                     uint64_t initseq);
+
+// pcg32_random()
+// pcg32_random_r(rng)
+//     Generate a uniformly distributed 32-bit random number
+
+uint32_t pcg32_random(void);
+uint32_t pcg32_random_r(pcg32_random_t* rng);
+
+// pcg32_boundedrand(bound):
+// pcg32_boundedrand_r(rng, bound):
+//     Generate a uniformly distributed number, r, where 0 <= r < bound
+
+uint32_t pcg32_boundedrand(uint32_t bound);
+uint32_t pcg32_boundedrand_r(pcg32_random_t* rng, uint32_t bound);
+
+#if __cplusplus
+}
+#endif
+
+#endif // PCG_BASIC_H_INCLUDED


### PR DESCRIPTION
Using `--include-subprojects` will fail if this directory isn't present, even though it's found during meson setup (through deckhandler)

See https://github.com/mesonbuild/meson/issues/12489

This was "exposed" to me after I did `git clean` a few days ago and tried to dist today.