### PR TITLE
Move most layout values into data/layout.conf 

### DIFF
--- a/data/layout.conf
+++ b/data/layout.conf
@@ -1,0 +1,80 @@
+[geometry]
+margin = 20
+button_x_spacing = 10
+back_btn_size = 96
+
+[timer]
+circle_timer_r = 50
+timer_border = 10
+
+[message_panel]
+msg_panel_x_offset = 30
+msg_panel_w = 420
+msg_panel_pad_x = 8
+msg_panel_pad_y = 6
+
+[settings_screen]
+settings_input_w = 350
+settings_input_y_offset = 40
+
+[cards]
+card_w = 80
+card_h = 50
+card_padding = 10
+
+[links]
+link_pad_x = 10
+link_pad_y = 2
+
+[gameplay]
+action_btn_x_gap = 50
+pot_boundary = 450
+board_y_offset = 40
+
+[indicators]
+indicator_pad = 14
+indicator_min_r = 24
+
+[nameplates]
+nameplate_pad = 20
+open_card_pad = 20
+nameplate_radius = 20
+
+[dialogs]
+confirm_quit_pad = 40
+confirm_quit_btn_gap = 20
+
+[menu]
+menu_title_y = 60
+menu_margin_x_offset = 100
+menu_connect_btn_y_offset = 160
+menu_connect_host_y_offset = 220
+menu_settings_x_right_offset = 700
+menu_settings_row_y_0 = 160
+menu_settings_row_y_1 = 360
+menu_settings_row_y_2 = 560
+menu_settings_save_y_offset = 750
+menu_links_center_x_offset = 200
+connect_settings_btn_gap = 20
+input_field_v_gap = 20
+connect_input_w_pad = 20
+connect_save_btn_gap = 12
+settings_save_btn_gap = 20
+version_x_offset = 40
+version_y_offset = 80
+checkbox_pad = 16
+
+[lobby]
+lobby_waiting_from_bottom = 200
+lobby_kick_x_divisor = 10
+lobby_kick_y_pct = 82
+kick_ban_btn_gap = 16
+game_kick_y_gap = 20
+
+[buttons]
+button_w_pad = 20
+button_h_pad = 10
+
+[inputs]
+input_text_pad_x = 8
+input_h_pad = 16

--- a/src/client.c
+++ b/src/client.c
@@ -59,7 +59,7 @@
 
 static const uint8_t coin_px = 96;
 
-#define POT_BOUNDARY 450
+
 
 #define ma_sound_start_checked(pSound) ma_sound_start_wrap((pSound), __FILE__, __LINE__)
 
@@ -151,7 +151,7 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
   }
 
   UITable_t gc_table = {0};
-  ui_table_begin(&gc_table, 0, g_viewport.y + MARGIN, 2);
+  ui_table_begin(&gc_table, 0, g_viewport.y + g_layout_cfg.margin, 2);
   for (int i = 0; i < MAX_CHOICES; i++)
     ui_table_add(&gc_table, i / 2, i % 2, &game_choice_button[i]->base);
   int gc_total_w = gc_table.col_width[0] + gc_table.col_width[1] + gc_table.col_spacing;
@@ -164,7 +164,7 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
   gc_bottom -= gc_table.row_spacing;
 
   button_deuces_wild->base.rect.x = (g_viewport.w - button_deuces_wild->base.rect.w) / 2;
-  button_deuces_wild->base.rect.y = gc_bottom + MARGIN;
+  button_deuces_wild->base.rect.y = gc_bottom + g_layout_cfg.margin;
 
   NickWidget_t *nick_widgets[MAX_PLAYERS] = {0};
   DealerWidget_t *dealer_widgets[MAX_PLAYERS] = {0};
@@ -190,8 +190,8 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
   TextWidget_t *tw_version_lobby =
       text_widget_create(version_str, font->fonts[FONT_VERSION], get_color(COLOR_WHITE));
   if (tw_version_lobby) {
-    ui_widget_place(&tw_version_lobby->base, g_viewport.x + MARGIN,
-                    g_viewport.y + g_viewport.h - tw_version_lobby->base.rect.h - MARGIN);
+    ui_widget_place(&tw_version_lobby->base, g_viewport.x + g_layout_cfg.margin,
+                    g_viewport.y + g_viewport.h - tw_version_lobby->base.rect.h - g_layout_cfg.margin);
     ui_register(&registry, &tw_version_lobby->base);
   }
 
@@ -213,7 +213,7 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
                                                  font->fonts[FONT_BOLD], (SDL_Keycode)0);
   btn_kick->base.rect.x = g_layout.lobby.kick_x;
   btn_kick->base.rect.y = g_layout.lobby.kick_y;
-  btn_ban->base.rect.x = btn_kick->base.rect.x + btn_kick->base.rect.w + 16;
+  btn_ban->base.rect.x = btn_kick->base.rect.x + btn_kick->base.rect.w + g_layout_cfg.kick_ban_btn_gap;
   btn_ban->base.rect.y = g_layout.lobby.kick_y;
   ui_register(&registry, &btn_kick->base);
   ui_register(&registry, &btn_ban->base);
@@ -222,7 +222,7 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
                                                         font->fonts[FONT_BOLD], (SDL_Keycode)0);
   if (btn_quit_lobby) {
     btn_quit_lobby->base.rect.x =
-        g_viewport.x + g_viewport.w - btn_quit_lobby->base.rect.w - MARGIN;
+        g_viewport.x + g_viewport.w - btn_quit_lobby->base.rect.w - g_layout_cfg.margin;
     btn_quit_lobby->base.rect.y = g_layout.menu.quit_y;
     ui_register(&registry, &btn_quit_lobby->base);
   }
@@ -233,7 +233,7 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
 
   char *back_img_path = canfigger_path_join(path->data, "images/arrow_back.png");
   ImageWidget_t *back_img =
-      back_img_path ? image_widget_create(back_img_path, back_btn_size, back_btn_size) : NULL;
+      back_img_path ? image_widget_create(back_img_path, g_layout_cfg.back_btn_size, g_layout_cfg.back_btn_size) : NULL;
   free(back_img_path);
   if (back_img) {
     back_img->base.rect.x = g_layout.menu.back_img_x;
@@ -265,7 +265,7 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
       if (t > 1.0f)
         t = 1.0f;
       int start_y = g_viewport.y + g_viewport.h * 2 / 3;
-      int end_y = g_viewport.y + g_viewport.h - back_btn_size - 20;
+      int end_y = g_viewport.y + g_viewport.h - g_layout_cfg.back_btn_size - 20;
       back_img->base.rect.y = start_y + (int)(t * (end_y - start_y));
     }
 
@@ -603,7 +603,7 @@ static void create_card_context(CardWidget_t card_context[MAX_PLAYERS][MAX_HAND_
       const int id = turn->id;
       DH_Card *card = &(turn->hand.card)[card_n];
       const SDL_Point card_pos = {
-          player_pos[id].x + card_n * (CARD_W + CARD_PADDING),
+          player_pos[id].x + card_n * (g_layout_cfg.card_w + g_layout_cfg.card_padding),
           player_pos[id].y,
       };
 
@@ -716,12 +716,12 @@ static void mark_winning_cards(CardWidget_t card_context[MAX_PLAYERS][MAX_HAND_S
 static void layout_board_cards(CardWidget_t card_context[MAX_PLAYERS][MAX_HAND_SIZE],
                                const int board_player_id, const SDL_Point *player_pos,
                                const int community_start) {
-  const int board_x = player_pos[0].x + (int)(CARD_W * 0.5f);
-  const int board_y = g_center.y - CARD_H * 2 - 40;
+  const int board_x = player_pos[0].x + (int)(g_layout_cfg.card_w * 0.5f);
+  const int board_y = g_center.y - g_layout_cfg.card_h * 2 - g_layout_cfg.board_y_offset;
 
   for (int card_n = community_start; card_n < MAX_HAND_SIZE; card_n++) {
     int slot = card_n - community_start;
-    SDL_Rect rect = {board_x + slot * (CARD_W + CARD_PADDING), board_y, CARD_W, CARD_H};
+    SDL_Rect rect = {board_x + slot * (g_layout_cfg.card_w + g_layout_cfg.card_padding), board_y, g_layout_cfg.card_w, g_layout_cfg.card_h};
     card_context[board_player_id][card_n].base.rect = rect;
 
     for (int i = 0; i < MAX_PLAYERS; i++) {
@@ -748,8 +748,8 @@ void layout_cards(CardWidget_t card_context[MAX_PLAYERS][MAX_HAND_SIZE], Player_
   do {
     for (int card_n = 0; card_n < MAX_HAND_SIZE; card_n++) {
       const int id = turn->id;
-      SDL_Rect rect = {player_pos[id].x + card_n * (CARD_W + CARD_PADDING), player_pos[id].y,
-                       CARD_W, CARD_H};
+      SDL_Rect rect = {player_pos[id].x + card_n * (g_layout_cfg.card_w + g_layout_cfg.card_padding), player_pos[id].y,
+                       g_layout_cfg.card_w, g_layout_cfg.card_h};
       card_context[id][card_n].base.rect = rect;
     }
     turn = get_next_connected_client(players_array, turn->id);
@@ -926,13 +926,13 @@ static void layout_indicator(Indicator_t *ind, int x, int y) {
 
 static void layout_game_name_indicator(Indicator_t *ind) {
   /* center between status panel right edge and timer left edge */
-  const int ind_cx = (g_layout.msg_panel_right + (g_center.x - CIRCLE_TIMER_R)) / 2;
+  const int ind_cx = (g_layout.msg_panel_right + (g_center.x - g_layout_cfg.circle_timer_r)) / 2;
   layout_indicator(ind, ind_cx - ind->rx, g_layout.timer.y - ind->base.rect.h / 2);
 }
 
 static void layout_deuces_wild_indicator(Indicator_t *ind) {
   /* mirror the game name indicator on the right side of the timer */
-  const int game_cx = (g_layout.msg_panel_right + (g_center.x - CIRCLE_TIMER_R)) / 2;
+  const int game_cx = (g_layout.msg_panel_right + (g_center.x - g_layout_cfg.circle_timer_r)) / 2;
   const int ind_cx = 2 * g_center.x - game_cx;
   layout_indicator(ind, ind_cx - ind->rx, g_layout.timer.y - ind->base.rect.h / 2);
 }
@@ -966,8 +966,8 @@ static __attribute__((noinline)) void draw_filled_circle(SDL_Renderer *r, int cx
 static void render_circle_timer(SDL_Renderer *renderer, SDL_Point center, float fill_ratio) {
   const int cx = center.x;
   const int cy = center.y;
-  const int outer_r = CIRCLE_TIMER_R; /* 50 */
-  const int border = 10;
+  const int outer_r = g_layout_cfg.circle_timer_r; /* 50 */
+  const int border = g_layout_cfg.timer_border;
   const int inner_r = outer_r - border; /* 40 */
 
   /* --- 3D border ring ---------------------------------------------------- */
@@ -1122,9 +1122,9 @@ static void render_text_pot(const char *text, const SDL_Point center, const Font
   int text_h = surface->h;
 
   /* Background circle */
-  int PAD = 14;
+  int PAD = g_layout_cfg.indicator_pad;
   int radius = (text_w > text_h ? text_w : text_h) / 2 + PAD;
-  if (radius < 24)
+  if (radius < g_layout_cfg.indicator_min_r)
     radius = 24;
 
   SDL_SetRenderDrawBlendMode(g_sdl_context->renderer, SDL_BLENDMODE_BLEND);
@@ -1185,7 +1185,7 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
       "You may only discard a maximum of 3 cards", font->fonts[FONT_BOLD], get_color(COLOR_WHITE));
   if (discard_hint_tw)
     ui_widget_place(&discard_hint_tw->base, g_layout.action_btn_x,
-                    action_bw[DISCARD]->base.rect.y + CARD_H);
+                    action_bw[DISCARD]->base.rect.y + g_layout_cfg.card_h);
   uint8_t last_max_allowed = 3;
 
   static const SDL_Keycode bet_hotkeys[MAX_BET_AMOUNTS] = {
@@ -1228,11 +1228,11 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
                                                        font->fonts[FONT_BOLD], (SDL_Keycode)0);
   game_btn_kick->base.rect.x = g_viewport.w / 10;
   /* Position above the status message panel, which starts at g_center.y */
-  game_btn_kick->base.rect.y = g_center.y - game_btn_kick->base.rect.h - 20;
-  game_btn_ban->base.rect.x = game_btn_kick->base.rect.x + game_btn_kick->base.rect.w + 16;
+  game_btn_kick->base.rect.y = g_center.y - game_btn_kick->base.rect.h - g_layout_cfg.game_kick_y_gap;
+  game_btn_ban->base.rect.x = game_btn_kick->base.rect.x + game_btn_kick->base.rect.w + g_layout_cfg.kick_ban_btn_gap;
   game_btn_ban->base.rect.y = game_btn_kick->base.rect.y;
-  game_btn_quit->base.rect.x = g_viewport.x + g_viewport.w - game_btn_quit->base.rect.w - MARGIN;
-  game_btn_quit->base.rect.y = g_viewport.y + MARGIN;
+  game_btn_quit->base.rect.x = g_viewport.x + g_viewport.w - game_btn_quit->base.rect.w - g_layout_cfg.margin;
+  game_btn_quit->base.rect.y = g_viewport.y + g_layout_cfg.margin;
   ui_register(&registry, &game_btn_kick->base);
   ui_register(&registry, &game_btn_ban->base);
   ui_register(&registry, &game_btn_quit->base);
@@ -1274,8 +1274,8 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
   for (int i = 0; i < SIZEOF_STATUS_MSGS; i++) {
     status_tw[i] = text_widget_create(" ", font->fonts[FONT_STATUS_MSG], get_color(COLOR_BLACK));
     if (status_tw[i])
-      ui_widget_place(&status_tw[i]->base, g_layout.msg_panel.x + MSG_PANEL_PAD_X,
-                      g_layout.msg_panel.y + MSG_PANEL_PAD_Y + i * (g_layout.status_line_h + 2));
+      ui_widget_place(&status_tw[i]->base, g_layout.msg_panel.x + g_layout_cfg.msg_panel_pad_x,
+                      g_layout.msg_panel.y + g_layout_cfg.msg_panel_pad_y + i * (g_layout.status_line_h + 2));
   }
 
   client_state.timer_start = SDL_GetTicks();
@@ -1376,7 +1376,7 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
     if (strcmp(client_state.server_status_str, last_status_str) != 0) {
       snprintf(last_status_str, LEN_STATUS_STR, "%s", client_state.server_status_str);
 
-      int max_w = g_layout.msg_panel.w - MSG_PANEL_PAD_X * 2;
+      int max_w = g_layout.msg_panel.w - g_layout_cfg.msg_panel_pad_x * 2;
       char wrapped[SIZEOF_STATUS_MSGS][LEN_STATUS_STR];
       int n = word_wrap_status(font->fonts[FONT_STATUS_MSG], client_state.server_status_str, max_w,
                                wrapped, SIZEOF_STATUS_MSGS);
@@ -1464,7 +1464,7 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
     prev_winner_declared = game_state->winner_declared;
 
     if (game_state->pot > coins * game_settings->bet_amounts[0] && coins < MAX_POT_COINS) {
-      uint32_t boundary = POT_BOUNDARY - (POT_BOUNDARY * 3 / 4) * coins / MAX_POT_COINS;
+      uint32_t boundary = g_layout_cfg.pot_boundary - (g_layout_cfg.pot_boundary * 3 / 4) * coins / MAX_POT_COINS;
       coin_in_pot[coins].offset.x = (int)pcg32_boundedrand_r(&rng, boundary) - (int)(boundary / 2);
       coin_in_pot[coins].offset.y = (int)pcg32_boundedrand_r(&rng, boundary) - (int)(boundary / 2);
       coin_in_pot[coins].angle = pcg32_boundedrand_r(&rng, 360);
@@ -1553,7 +1553,7 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
       max_col_w[0] = nick_min_w;
 
     // Second pass: layout with uniform column widths, nick left-aligned
-    const int np_pad = 20;
+    const int np_pad = g_layout_cfg.nameplate_pad;
     const int col_spacing_val = 20; // matches ui_table_begin default
     int total_max_w = max_col_w[0] + max_col_w[1] + max_col_w[2] + 2 * col_spacing_val;
     SDL_Rect turn_outline = {0};
@@ -1562,8 +1562,8 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
       if (!game_nick_widgets[id] || !game_coin_widgets[id] || !game_coins_tw[id])
         continue;
       UITable_t player_table = {0};
-      ui_table_begin(&player_table, g_layout.player_pos[id].x + CARD_W / 2,
-                     g_layout.player_pos[id].y + (int)(CARD_H * 1.2), 3);
+      ui_table_begin(&player_table, g_layout.player_pos[id].x + g_layout_cfg.card_w / 2,
+                     g_layout.player_pos[id].y + (int)(g_layout_cfg.card_h * 1.2), 3);
       for (int c = 0; c < 3; c++)
         player_table.col_width[c] = max_col_w[c];
       player_table.col_align[0] = 1; // left-align nick
@@ -1586,14 +1586,14 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
         draw_nameplate(sdl_context->renderer, nameplate_rects[id], 150);
     }
 
-    const int open_pad = 20;
+    const int open_pad = g_layout_cfg.open_card_pad;
     const int open_h = coin_px / 2 + open_pad * 2;
     const int open_w = (total_max_w > 0) ? total_max_w + 2 * open_pad : 280;
     for (int8_t id = 0; id < MAX_PLAYERS; id++) {
       if (game_state->player[id].is_connected)
         continue;
-      int ox = g_layout.player_pos[id].x + CARD_W / 2 - open_pad;
-      int oy = g_layout.player_pos[id].y + (int)(CARD_H * 1.2) - open_pad;
+      int ox = g_layout.player_pos[id].x + g_layout_cfg.card_w / 2 - open_pad;
+      int oy = g_layout.player_pos[id].y + (int)(g_layout_cfg.card_h * 1.2) - open_pad;
       SDL_Rect open_rect = {ox, oy, open_w, open_h};
       draw_nameplate(sdl_context->renderer, open_rect, 70);
       if (open_seat_tw[id]) {
@@ -1643,7 +1643,7 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
       if (!game_state->player[id].is_connected || game_state->player[id].in)
         continue;
       SDL_Rect card_area = {g_layout.player_pos[id].x, g_layout.player_pos[id].y,
-                            MAX_HAND_SIZE * (CARD_W + CARD_PADDING) - CARD_PADDING, CARD_H};
+                            MAX_HAND_SIZE * (g_layout_cfg.card_w + g_layout_cfg.card_padding) - g_layout_cfg.card_padding, g_layout_cfg.card_h};
       SDL_RenderFillRect(sdl_context->renderer, &card_area);
       if (nameplate_rects[id].w > 0)
         SDL_RenderFillRect(sdl_context->renderer, &nameplate_rects[id]);
@@ -1718,46 +1718,46 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
         if (client_state.bet_check_fold) {
           action_bw[BET]->base.rect.x = x_offset;
           ui_widget_render(&action_bw[BET]->base);
-          x_offset = action_bw[BET]->base.rect.x + action_bw[BET]->base.rect.w + BUTTON_X_SPACING;
+          x_offset = action_bw[BET]->base.rect.x + action_bw[BET]->base.rect.w + g_layout_cfg.button_x_spacing;
 
           action_bw[CHECK]->base.rect.x = x_offset;
           ui_widget_render(&action_bw[CHECK]->base);
           x_offset =
-              action_bw[CHECK]->base.rect.x + action_bw[CHECK]->base.rect.w + BUTTON_X_SPACING;
+              action_bw[CHECK]->base.rect.x + action_bw[CHECK]->base.rect.w + g_layout_cfg.button_x_spacing;
         } else if (client_state.call_raise_fold) {
           action_bw[CALL]->base.rect.x = x_offset;
           ui_widget_render(&action_bw[CALL]->base);
-          x_offset = action_bw[CALL]->base.rect.x + action_bw[CALL]->base.rect.w + BUTTON_X_SPACING;
+          x_offset = action_bw[CALL]->base.rect.x + action_bw[CALL]->base.rect.w + g_layout_cfg.button_x_spacing;
 
           action_bw[RAISE]->base.rect.x = x_offset;
           action_bw[RAISE]->interactive = game_state->raises_remaining > 0;
           if (action_bw[RAISE]->interactive)
             ui_widget_render(&action_bw[RAISE]->base);
           x_offset =
-              action_bw[RAISE]->base.rect.x + action_bw[RAISE]->base.rect.w + BUTTON_X_SPACING;
+              action_bw[RAISE]->base.rect.x + action_bw[RAISE]->base.rect.w + g_layout_cfg.button_x_spacing;
         } else if (client_state.call_complete_fold) {
           action_bw[CALL]->base.rect.x = x_offset;
           ui_widget_render(&action_bw[CALL]->base);
-          x_offset = action_bw[CALL]->base.rect.x + action_bw[CALL]->base.rect.w + BUTTON_X_SPACING;
+          x_offset = action_bw[CALL]->base.rect.x + action_bw[CALL]->base.rect.w + g_layout_cfg.button_x_spacing;
 
           action_bw[COMPLETE]->base.rect.x = x_offset;
           action_bw[COMPLETE]->interactive = game_state->raises_remaining > 0;
           if (action_bw[COMPLETE]->interactive)
             ui_widget_render(&action_bw[COMPLETE]->base);
           x_offset = action_bw[COMPLETE]->base.rect.x + action_bw[COMPLETE]->base.rect.w +
-                     BUTTON_X_SPACING;
+                     g_layout_cfg.button_x_spacing;
         } else if (client_state.complete_check_fold) {
           action_bw[COMPLETE]->base.rect.x = x_offset;
           action_bw[COMPLETE]->interactive = game_state->raises_remaining > 0;
           if (action_bw[COMPLETE]->interactive)
             ui_widget_render(&action_bw[COMPLETE]->base);
           x_offset = action_bw[COMPLETE]->base.rect.x + action_bw[COMPLETE]->base.rect.w +
-                     BUTTON_X_SPACING;
+                     g_layout_cfg.button_x_spacing;
 
           action_bw[CHECK]->base.rect.x = x_offset;
           ui_widget_render(&action_bw[CHECK]->base);
           x_offset =
-              action_bw[CHECK]->base.rect.x + action_bw[CHECK]->base.rect.w + BUTTON_X_SPACING;
+              action_bw[CHECK]->base.rect.x + action_bw[CHECK]->base.rect.w + g_layout_cfg.button_x_spacing;
         }
         action_bw[FOLD]->base.rect.x = x_offset;
         ui_widget_render(&action_bw[FOLD]->base);

--- a/src/dc_config.c
+++ b/src/dc_config.c
@@ -36,6 +36,7 @@
 #endif
 
 #include "dc_config.h"
+#include "layout.h"
 #include "util.h"
 
 const ConfigEntry player_config_entries[] = {
@@ -88,6 +89,72 @@ _Static_assert(ARRAY_SIZE(player_config_entries) - 1 <= MAX_PLAYER_CONFIG_ENTRIE
                "Too many player config entries; increase MAX_PLAYER_CONFIG_ENTRIES");
 _Static_assert(ARRAY_SIZE(server_config_entries) - 1 <= MAX_SERVER_CONFIG_ENTRIES,
                "Too many server config entries; increase MAX_SERVER_CONFIG_ENTRIES");
+
+#define LC(key, default_val, field) \
+  {key, CFG_TYPE_INT, default_val, offsetof(LayoutConfig_t, field), sizeof(int)}
+
+const ConfigEntry layout_config_entries[] = {
+    LC("margin",                    "20",  margin),
+    LC("button_x_spacing",         "10",  button_x_spacing),
+    LC("back_btn_size",             "96",  back_btn_size),
+    LC("circle_timer_r",           "50",  circle_timer_r),
+    LC("msg_panel_x_offset",       "30",  msg_panel_x_offset),
+    LC("msg_panel_w",             "420",  msg_panel_w),
+    LC("msg_panel_pad_x",           "8",  msg_panel_pad_x),
+    LC("msg_panel_pad_y",           "6",  msg_panel_pad_y),
+    LC("settings_input_w",        "350",  settings_input_w),
+    LC("settings_input_y_offset",  "40",  settings_input_y_offset),
+    LC("card_w",                   "80",  card_w),
+    LC("card_h",                   "50",  card_h),
+    LC("card_padding",             "10",  card_padding),
+    LC("link_pad_x",               "10",  link_pad_x),
+    LC("link_pad_y",                "2",  link_pad_y),
+    LC("action_btn_x_gap",         "50",  action_btn_x_gap),
+    LC("menu_title_y",             "60",  menu_title_y),
+    LC("menu_margin_x_offset",    "100",  menu_margin_x_offset),
+    LC("menu_connect_btn_y_offset",  "160", menu_connect_btn_y_offset),
+    LC("menu_connect_host_y_offset", "220", menu_connect_host_y_offset),
+    LC("menu_settings_x_right_offset", "700", menu_settings_x_right_offset),
+    LC("menu_settings_row_y_0",   "160",  menu_settings_row_y_0),
+    LC("menu_settings_row_y_1",   "360",  menu_settings_row_y_1),
+    LC("menu_settings_row_y_2",   "560",  menu_settings_row_y_2),
+    LC("menu_settings_save_y_offset", "750", menu_settings_save_y_offset),
+    LC("menu_links_center_x_offset", "200", menu_links_center_x_offset),
+    LC("lobby_waiting_from_bottom", "200", lobby_waiting_from_bottom),
+    LC("lobby_kick_x_divisor",     "10",  lobby_kick_x_divisor),
+    LC("lobby_kick_y_pct",         "82",  lobby_kick_y_pct),
+    LC("kick_ban_btn_gap",         "16",  kick_ban_btn_gap),
+    LC("game_kick_y_gap",          "20",  game_kick_y_gap),
+    LC("pot_boundary",            "450",  pot_boundary),
+    LC("board_y_offset",           "40",  board_y_offset),
+    LC("timer_border",             "10",  timer_border),
+    LC("indicator_pad",            "14",  indicator_pad),
+    LC("indicator_min_r",          "24",  indicator_min_r),
+    LC("nameplate_pad",            "20",  nameplate_pad),
+    LC("open_card_pad",            "20",  open_card_pad),
+    LC("nameplate_radius",         "20",  nameplate_radius),
+    LC("confirm_quit_pad",         "40",  confirm_quit_pad),
+    LC("confirm_quit_btn_gap",     "20",  confirm_quit_btn_gap),
+    LC("connect_settings_btn_gap", "20",  connect_settings_btn_gap),
+    LC("input_field_v_gap",        "20",  input_field_v_gap),
+    LC("connect_input_w_pad",      "20",  connect_input_w_pad),
+    LC("connect_save_btn_gap",     "12",  connect_save_btn_gap),
+    LC("settings_save_btn_gap",    "20",  settings_save_btn_gap),
+    LC("version_x_offset",         "40",  version_x_offset),
+    LC("version_y_offset",         "80",  version_y_offset),
+    LC("checkbox_pad",             "16",  checkbox_pad),
+    LC("button_w_pad",             "20",  button_w_pad),
+    LC("button_h_pad",             "10",  button_h_pad),
+    LC("input_text_pad_x",          "8",  input_text_pad_x),
+    LC("input_h_pad",              "16",  input_h_pad),
+    {0}};
+
+#undef LC
+
+const size_t layout_config_entry_count = ARRAY_SIZE(layout_config_entries) - 1;
+
+_Static_assert(ARRAY_SIZE(layout_config_entries) - 1 <= MAX_LAYOUT_CONFIG_ENTRIES,
+               "Too many layout config entries; increase MAX_LAYOUT_CONFIG_ENTRIES");
 
 #define CFG_SET_SIGNED(TYPE, MIN, MAX)                                                             \
   do {                                                                                             \
@@ -369,5 +436,50 @@ PlayerConfig_t get_player_config(void) {
   free(cfg_pathname);
 
   config.loaded = true;
+  return config;
+}
+
+LayoutConfig_t get_layout_config(const char *data_dir) {
+  LayoutConfig_t config = {0};
+
+  char *cfg_pathname = canfigger_path_join(data_dir, "layout.conf");
+  if (!cfg_pathname) {
+    fprintf(stderr, "canfigger_path_join failed for layout.conf\n");
+    goto use_defaults;
+  }
+
+  printf("Reading layout config: %s\n", cfg_pathname);
+  struct Canfigger *cfg_node = canfigger_parse_file(cfg_pathname, ',');
+  free(cfg_pathname);
+  if (!cfg_node)
+    goto use_defaults;
+
+  bool found_keys[MAX_LAYOUT_CONFIG_ENTRIES];
+  memset(found_keys, 0, sizeof(found_keys));
+
+  while (cfg_node) {
+    for (size_t i = 0; i < layout_config_entry_count; i++) {
+      if (strcasecmp(cfg_node->key, layout_config_entries[i].key) == 0) {
+        config_set_from_string_real(&config, &layout_config_entries[i],
+                                    cfg_node->value ? cfg_node->value
+                                                    : layout_config_entries[i].default_value);
+        found_keys[i] = true;
+        break;
+      }
+    }
+    canfigger_free_current_key_node_advance(&cfg_node);
+  }
+
+  for (size_t i = 0; i < layout_config_entry_count; i++)
+    if (!found_keys[i])
+      config_set_from_string_real(&config, &layout_config_entries[i],
+                                  layout_config_entries[i].default_value);
+
+  return config;
+
+use_defaults:
+  for (size_t i = 0; i < layout_config_entry_count; i++)
+    config_set_from_string_real(&config, &layout_config_entries[i],
+                                layout_config_entries[i].default_value);
   return config;
 }

--- a/src/dc_config.h
+++ b/src/dc_config.h
@@ -84,12 +84,15 @@ typedef struct {
 
 #define MAX_PLAYER_CONFIG_ENTRIES 16
 #define MAX_SERVER_CONFIG_ENTRIES 32
+#define MAX_LAYOUT_CONFIG_ENTRIES 64
 
 extern const ConfigEntry player_config_entries[];
 extern const ConfigEntry server_config_entries[];
+extern const ConfigEntry layout_config_entries[];
 
 extern const size_t player_config_entry_count;
 extern const size_t server_config_entry_count;
+extern const size_t layout_config_entry_count;
 
 ServerConfig_t get_server_config(Path_t *path, const CliArgs_t *cli_args);
 

--- a/src/globals.c
+++ b/src/globals.c
@@ -35,4 +35,3 @@ pcg32_random_t rng;
 SDL_Rect g_viewport = {0};
 SDL_Point g_center = {0};
 
-const int back_btn_size = 96;

--- a/src/globals.h
+++ b/src/globals.h
@@ -40,6 +40,4 @@ extern pcg32_random_t rng;
 extern SDL_Rect g_viewport;
 extern SDL_Point g_center;
 
-extern const int back_btn_size;
-
 #endif

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -105,8 +105,8 @@ bool confirm_quit(TTF_Font *font) {
     return false;
   }
 
-  const int pad = 40;
-  const int btn_gap = 20;
+  const int pad = g_layout_cfg.confirm_quit_pad;
+  const int btn_gap = g_layout_cfg.confirm_quit_btn_gap;
   const int dialog_w =
       SDL_max(msg_tw->base.rect.w + pad * 2,
               btn_cancel->base.rect.w + btn_gap + btn_quit_w->base.rect.w + pad * 2);
@@ -181,7 +181,7 @@ bool confirm_quit(TTF_Font *font) {
 }
 
 void draw_nameplate(SDL_Renderer *r, SDL_Rect rect, uint8_t alpha) {
-  const int radius = 20;
+  const int radius = g_layout_cfg.nameplate_radius;
   SDL_SetRenderDrawBlendMode(r, SDL_BLENDMODE_BLEND);
   SDL_SetRenderDrawColor(r, 0, 0, 0, alpha);
 

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -39,10 +39,6 @@
 #define LOGICAL_WIDTH 1920
 #define LOGICAL_HEIGHT 1080
 
-#define MARGIN 20
-
-#define BUTTON_X_SPACING 10
-
 typedef enum {
   COLOR_WHITE,
   COLOR_LIGHTGRAY,

--- a/src/layout.c
+++ b/src/layout.c
@@ -26,12 +26,11 @@
 
 */
 
-#include "globals.h"      /* full dep chain: tcpme → types.h; also g_viewport, g_center */
-#include "layout.h"       /* GameLayout_t, layout_init, layout_compute */
-#include "graphics.h"     /* MARGIN */
-#include "widgets/card.h" /* CARD_W, CARD_H, CARD_PADDING */
+#include "globals.h"
+#include "layout.h"
 
 GameLayout_t g_layout;
+LayoutConfig_t g_layout_cfg;
 
 void layout_init(int status_font_line_h) {
   g_layout.status_line_h = status_font_line_h;
@@ -40,60 +39,60 @@ void layout_init(int status_font_line_h) {
 
 void layout_compute(void) {
   SDL_Rect vp = g_viewport;
+  const LayoutConfig_t *c = &g_layout_cfg;
 
-  int right_x = vp.x + vp.w - (CARD_W * 7 + CARD_PADDING * 7 + MARGIN);
+  int right_x = vp.x + vp.w - (c->card_w * 7 + c->card_padding * 7 + c->margin);
 
-  g_layout.player_pos[0].x = vp.x + MARGIN;
-  g_layout.player_pos[0].y = vp.y + CARD_H * 4;
+  g_layout.player_pos[0].x = vp.x + c->margin;
+  g_layout.player_pos[0].y = vp.y + c->card_h * 4;
 
-  g_layout.player_pos[1].x = vp.x + MARGIN;
-  g_layout.player_pos[1].y = vp.y + CARD_H;
+  g_layout.player_pos[1].x = vp.x + c->margin;
+  g_layout.player_pos[1].y = vp.y + c->card_h;
 
   g_layout.player_pos[2].x = right_x;
-  g_layout.player_pos[2].y = vp.y + CARD_H;
+  g_layout.player_pos[2].y = vp.y + c->card_h;
 
   g_layout.player_pos[3].x = right_x;
-  g_layout.player_pos[3].y = vp.y + CARD_H * 4;
+  g_layout.player_pos[3].y = vp.y + c->card_h * 4;
 
   g_layout.player_pos[4].x = right_x;
-  g_layout.player_pos[4].y = vp.y + CARD_H * 7;
+  g_layout.player_pos[4].y = vp.y + c->card_h * 7;
 
   g_layout.timer.x = g_center.x;
-  g_layout.timer.y = vp.y + vp.h - MARGIN - CIRCLE_TIMER_R;
+  g_layout.timer.y = vp.y + vp.h - c->margin - c->circle_timer_r;
 
   g_layout.table_center.x = g_center.x;
   g_layout.table_center.y = g_center.y;
 
-  g_layout.msg_panel.x = vp.x + MSG_PANEL_X_OFFSET;
+  g_layout.msg_panel.x = vp.x + c->msg_panel_x_offset;
   g_layout.msg_panel.y = g_center.y;
-  g_layout.msg_panel.w = MSG_PANEL_W;
+  g_layout.msg_panel.w = c->msg_panel_w;
   g_layout.msg_panel.h = g_layout.status_line_h > 0
-      ? (g_layout.status_line_h + 2) * SIZEOF_STATUS_MSGS + MSG_PANEL_PAD_Y * 2
+      ? (g_layout.status_line_h + 2) * SIZEOF_STATUS_MSGS + c->msg_panel_pad_y * 2
       : 0;
 
   g_layout.msg_panel_right = g_layout.msg_panel.x + g_layout.msg_panel.w;
 
-  /* Buttons start just to the right of the message panel */
-  g_layout.action_btn_x = g_layout.msg_panel_right + 50;
+  g_layout.action_btn_x = g_layout.msg_panel_right + c->action_btn_x_gap;
 
   /* Menu screens (connect + settings) */
   g_layout.menu.title_x            = g_center.x * 2 / 3;
-  g_layout.menu.title_y            = 60;
-  g_layout.menu.margin_x           = vp.x + 100;
-  g_layout.menu.connect_btn_y      = vp.y + 160;
-  g_layout.menu.connect_host_y     = vp.y + 220;
-  g_layout.menu.quit_y             = vp.y + MARGIN;
-  g_layout.menu.settings_x_right   = vp.x + 700;
-  g_layout.menu.settings_row_y[0]  = vp.y + 160;
-  g_layout.menu.settings_row_y[1]  = vp.y + 360;
-  g_layout.menu.settings_row_y[2]  = vp.y + 560;
-  g_layout.menu.settings_save_y    = vp.y + 750;
-  g_layout.menu.back_img_x         = vp.x + vp.w - back_btn_size - MARGIN;
+  g_layout.menu.title_y            = c->menu_title_y;
+  g_layout.menu.margin_x           = vp.x + c->menu_margin_x_offset;
+  g_layout.menu.connect_btn_y      = vp.y + c->menu_connect_btn_y_offset;
+  g_layout.menu.connect_host_y     = vp.y + c->menu_connect_host_y_offset;
+  g_layout.menu.quit_y             = vp.y + c->margin;
+  g_layout.menu.settings_x_right   = vp.x + c->menu_settings_x_right_offset;
+  g_layout.menu.settings_row_y[0]  = vp.y + c->menu_settings_row_y_0;
+  g_layout.menu.settings_row_y[1]  = vp.y + c->menu_settings_row_y_1;
+  g_layout.menu.settings_row_y[2]  = vp.y + c->menu_settings_row_y_2;
+  g_layout.menu.settings_save_y    = vp.y + c->menu_settings_save_y_offset;
+  g_layout.menu.back_img_x         = vp.x + vp.w - c->back_btn_size - c->margin;
   g_layout.menu.back_img_y         = vp.y + vp.h / 2;
-  g_layout.menu.links_center_x     = g_center.x + 200;
+  g_layout.menu.links_center_x     = g_center.x + c->menu_links_center_x_offset;
 
   /* Lobby (game selection) screen */
-  g_layout.lobby.waiting_y = vp.y + vp.h - 200;
-  g_layout.lobby.kick_x    = vp.x + vp.w / 10;
-  g_layout.lobby.kick_y    = vp.y + vp.h * 82 / 100;
+  g_layout.lobby.waiting_y = vp.y + vp.h - c->lobby_waiting_from_bottom;
+  g_layout.lobby.kick_x    = vp.x + vp.w / c->lobby_kick_x_divisor;
+  g_layout.lobby.kick_y    = vp.y + vp.h * c->lobby_kick_y_pct / 100;
 }

--- a/src/layout.h
+++ b/src/layout.h
@@ -32,21 +32,69 @@
 #include <SDL2/SDL.h>
 #include "types.h"
 
-/* Radius of the circular countdown timer */
-#define CIRCLE_TIMER_R 50
-
-/* Status message panel geometry */
-#define MSG_PANEL_X_OFFSET 30
-#define MSG_PANEL_W        420
-#define MSG_PANEL_PAD_X    8
-#define MSG_PANEL_PAD_Y    6
-
-/* Number of scrolling status message lines shown in the panel */
+/* Number of scrolling status message lines shown in the panel.
+ * Must remain a compile-time constant (used as static array dimension). */
 #define SIZEOF_STATUS_MSGS 16
 
-/* Settings screen fixed input geometry */
-#define SETTINGS_INPUT_W        350
-#define SETTINGS_INPUT_Y_OFFSET 40
+typedef struct {
+  int margin;
+  int button_x_spacing;
+  int back_btn_size;
+  int circle_timer_r;
+  int msg_panel_x_offset;
+  int msg_panel_w;
+  int msg_panel_pad_x;
+  int msg_panel_pad_y;
+  int settings_input_w;
+  int settings_input_y_offset;
+  int card_w;
+  int card_h;
+  int card_padding;
+  int link_pad_x;
+  int link_pad_y;
+  int action_btn_x_gap;
+  int menu_title_y;
+  int menu_margin_x_offset;
+  int menu_connect_btn_y_offset;
+  int menu_connect_host_y_offset;
+  int menu_settings_x_right_offset;
+  int menu_settings_row_y_0;
+  int menu_settings_row_y_1;
+  int menu_settings_row_y_2;
+  int menu_settings_save_y_offset;
+  int menu_links_center_x_offset;
+  int lobby_waiting_from_bottom;
+  int lobby_kick_x_divisor;
+  int lobby_kick_y_pct;
+  int kick_ban_btn_gap;
+  int game_kick_y_gap;
+  int pot_boundary;
+  int board_y_offset;
+  int timer_border;
+  int indicator_pad;
+  int indicator_min_r;
+  int nameplate_pad;
+  int open_card_pad;
+  int nameplate_radius;
+  int confirm_quit_pad;
+  int confirm_quit_btn_gap;
+  int connect_settings_btn_gap;
+  int input_field_v_gap;
+  int connect_input_w_pad;
+  int connect_save_btn_gap;
+  int settings_save_btn_gap;
+  int version_x_offset;
+  int version_y_offset;
+  int checkbox_pad;
+  int button_w_pad;
+  int button_h_pad;
+  int input_text_pad_x;
+  int input_h_pad;
+} LayoutConfig_t;
+
+extern LayoutConfig_t g_layout_cfg;
+
+LayoutConfig_t get_layout_config(const char *data_dir);
 
 typedef struct {
   SDL_Point player_pos[MAX_PLAYERS]; /* top-left origin of each player's card row */

--- a/src/main.c
+++ b/src/main.c
@@ -62,13 +62,13 @@ static int menu_display_connect(PlayerConfig_t *player_config, char *host_str, u
 
   button_connect->base.rect.x = g_layout.menu.margin_x;
   button_connect->base.rect.y = g_layout.menu.connect_btn_y;
-  button_settings->base.rect.x = g_layout.menu.margin_x + button_connect->base.rect.w + 20;
+  button_settings->base.rect.x = g_layout.menu.margin_x + button_connect->base.rect.w + g_layout_cfg.connect_settings_btn_gap;
   button_settings->base.rect.y = g_layout.menu.connect_btn_y;
 
   int input_w;
   if (TTF_SizeUTF8(font->fonts[FONT_DEFAULT], "255.255.255.255", &input_w, NULL) != 0)
     input_w = 150;
-  input_w += 20;
+  input_w += g_layout_cfg.connect_input_w_pad;
 
   InputWidget_t *host_input =
       input_widget_create(host_str, font->fonts[FONT_DEFAULT], input_w, CFG_TYPE_STRING);
@@ -86,7 +86,7 @@ static int menu_display_connect(PlayerConfig_t *player_config, char *host_str, u
   if (!port_input)
     goto err;
   port_input->base.rect.x = g_layout.menu.margin_x;
-  port_input->base.rect.y = host_input->base.rect.y + host_input->base.rect.h + 20;
+  port_input->base.rect.y = host_input->base.rect.y + host_input->base.rect.h + g_layout_cfg.input_field_v_gap;
   ui_register(&reg, &port_input->base);
 
   ButtonWidget_t *button_save = button_widget_create(
@@ -101,26 +101,26 @@ static int menu_display_connect(PlayerConfig_t *player_config, char *host_str, u
   if (!button_defaults)
     goto err;
   ui_register(&reg, &button_defaults->base);
-  button_save->base.rect.x = g_layout.menu.margin_x + input_w + 12;
+  button_save->base.rect.x = g_layout.menu.margin_x + input_w + g_layout_cfg.connect_save_btn_gap;
   {
     int span_top = host_input->base.rect.y;
     int span_bot = port_input->base.rect.y + port_input->base.rect.h;
     button_save->base.rect.y = (span_top + span_bot) / 2 - button_save->base.rect.h / 2;
   }
-  button_defaults->base.rect.x = button_save->base.rect.x + button_save->base.rect.w + 12;
+  button_defaults->base.rect.x = button_save->base.rect.x + button_save->base.rect.w + g_layout_cfg.connect_save_btn_gap;
   button_defaults->base.rect.y = button_save->base.rect.y;
 
   ButtonWidget_t *btn_quit_connect = button_widget_create("X", (EColor_t){COLOR_WHITE, COLOR_RED},
                                                           font->fonts[FONT_BOLD], (SDL_Keycode)0);
   if (btn_quit_connect) {
     btn_quit_connect->base.rect.x =
-        g_viewport.x + g_viewport.w - btn_quit_connect->base.rect.w - MARGIN;
+        g_viewport.x + g_viewport.w - btn_quit_connect->base.rect.w - g_layout_cfg.margin;
     btn_quit_connect->base.rect.y = g_layout.menu.quit_y;
     ui_register(&reg, &btn_quit_connect->base);
   }
 
-  SDL_Rect input_nick_pos = {g_layout.menu.margin_x, port_input->base.rect.y + port_input->base.rect.h + 20, 0,
-                             0};
+  SDL_Rect input_nick_pos = {g_layout.menu.margin_x,
+                             port_input->base.rect.y + port_input->base.rect.h + g_layout_cfg.input_field_v_gap, 0, 0};
 
   InputWidget_t *focused_inputs[2] = {host_input, port_input};
   int focused_slot = 0;
@@ -139,7 +139,7 @@ static int menu_display_connect(PlayerConfig_t *player_config, char *host_str, u
   TextWidget_t *tw_version =
       text_widget_create(version, font->fonts[FONT_VERSION], get_color(COLOR_WHITE));
   if (tw_version)
-    ui_widget_place(&tw_version->base, g_layout.menu.title_x + 40, g_layout.menu.title_y + 80);
+    ui_widget_place(&tw_version->base, g_layout.menu.title_x + g_layout_cfg.version_x_offset, g_layout.menu.title_y + g_layout_cfg.version_y_offset);
 
   TextWidget_t *tw_nick =
       text_widget_create(player_config->nick, font->fonts[FONT_DEFAULT], get_color(COLOR_BLACK));
@@ -323,15 +323,15 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
   const int x_left         = g_layout.menu.margin_x;
   const int x_right        = g_layout.menu.settings_x_right;
   const int *row_y         = g_layout.menu.settings_row_y;
-  const int input_y_offset = SETTINGS_INPUT_Y_OFFSET;
-  const int input_w        = SETTINGS_INPUT_W;
+  const int input_y_offset = g_layout_cfg.settings_input_y_offset;
+  const int input_w        = g_layout_cfg.settings_input_w;
 
   UIRegistry_t reg = {0};
 
   /* Back arrow image (top-left) */
   char *back_img_path = canfigger_path_join(path->data, "images/arrow_back.png");
   ImageWidget_t *back_img =
-      back_img_path ? image_widget_create(back_img_path, back_btn_size, back_btn_size) : NULL;
+      back_img_path ? image_widget_create(back_img_path, g_layout_cfg.back_btn_size, g_layout_cfg.back_btn_size) : NULL;
   free(back_img_path);
   if (back_img) {
     back_img->base.rect.x = g_layout.menu.back_img_x;
@@ -349,7 +349,7 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
       *(const bool *)((const uint8_t *)player_config + player_config_entries[bool_idx].offset);
   int checkbox_size;
   TTF_SizeUTF8(font->fonts[FONT_DEFAULT], "Ag", NULL, &checkbox_size);
-  checkbox_size += 16;
+  checkbox_size += g_layout_cfg.checkbox_pad;
   CheckboxWidget_t *turn_cb = checkbox_widget_create(init_checked, checkbox_size);
   if (turn_cb)
     ui_register(&reg, &turn_cb->base);
@@ -440,7 +440,7 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
     ui_destroy_all(&reg);
     return;
   }
-  btn_defaults->base.rect.x = btn_save->base.rect.x + btn_save->base.rect.w + 20;
+  btn_defaults->base.rect.x = btn_save->base.rect.x + btn_save->base.rect.w + g_layout_cfg.settings_save_btn_gap;
   btn_defaults->base.rect.y = btn_save->base.rect.y;
   ui_register(&reg, &btn_defaults->base);
 
@@ -448,7 +448,7 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
                                                            font->fonts[FONT_BOLD], (SDL_Keycode)0);
   if (btn_quit_settings) {
     btn_quit_settings->base.rect.x =
-        g_viewport.x + g_viewport.w - btn_quit_settings->base.rect.w - MARGIN;
+        g_viewport.x + g_viewport.w - btn_quit_settings->base.rect.w - g_layout_cfg.margin;
     btn_quit_settings->base.rect.y = g_layout.menu.quit_y;
     ui_register(&reg, &btn_quit_settings->base);
   }
@@ -620,7 +620,7 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
       if (t > 1.0f)
         t = 1.0f;
       int start_y = g_viewport.y + g_viewport.h * 2 / 3;
-      int end_y = g_viewport.y + g_viewport.h - back_btn_size - 20;
+      int end_y = g_viewport.y + g_viewport.h - g_layout_cfg.back_btn_size - 20;
       back_img->base.rect.y = start_y + (int)(t * (end_y - start_y));
     }
 
@@ -875,6 +875,7 @@ int main(int argc, char *argv[]) {
       return -1;
   }
 
+  g_layout_cfg = get_layout_config(path.data);
   layout_init(TTF_FontHeight(font.fonts[FONT_STATUS_MSG]));
 
   PlayerConfig_t player_config = get_player_config();

--- a/src/widgets/button.c
+++ b/src/widgets/button.c
@@ -104,8 +104,8 @@ ButtonWidget_t *button_widget_create(const char *text, EColor_t color, TTF_Font 
     th = 20;
   }
 
-  bw->base.rect.w = tw + 20;
-  bw->base.rect.h = th + 10;
+  bw->base.rect.w = tw + g_layout_cfg.button_w_pad;
+  bw->base.rect.h = th + g_layout_cfg.button_h_pad;
   bw->base.render = button_widget_render;
   bw->base.destroy = button_widget_destroy;
 

--- a/src/widgets/card.c
+++ b/src/widgets/card.c
@@ -544,8 +544,8 @@ static void card_widget_render(UIWidget_t *w) {
     exit(EXIT_FAILURE);
   }
 
-  SDL_Rect textRect = {w->rect.x + (CARD_W - textSurface->w) / 2,
-                       w->rect.y + (CARD_H - textSurface->h) / 2, textSurface->w, textSurface->h};
+  SDL_Rect textRect = {w->rect.x + (g_layout_cfg.card_w - textSurface->w) / 2,
+                       w->rect.y + (g_layout_cfg.card_h - textSurface->h) / 2, textSurface->w, textSurface->h};
 
   SDL_RenderCopy(renderer, textTexture, NULL, &textRect);
   SDL_FreeSurface(textSurface);
@@ -556,8 +556,8 @@ static void card_widget_destroy(UIWidget_t *w) { free(w); }
 
 void card_widget_init(CardWidget_t *cw, TTF_Font *font) {
   cw->font = font;
-  cw->base.rect.w = CARD_W;
-  cw->base.rect.h = CARD_H;
+  cw->base.rect.w = g_layout_cfg.card_w;
+  cw->base.rect.h = g_layout_cfg.card_h;
   cw->base.render = card_widget_render;
   cw->base.destroy = card_widget_destroy;
 }

--- a/src/widgets/card.h
+++ b/src/widgets/card.h
@@ -32,9 +32,6 @@
 #include "ui_widget.h"
 #include <SDL2/SDL_ttf.h>
 
-#define CARD_W 80
-#define CARD_H 50
-#define CARD_PADDING 10
 #define SIZEOF_CARD_TEXT 20
 
 typedef struct {

--- a/src/widgets/input.c
+++ b/src/widgets/input.c
@@ -56,8 +56,8 @@ static void input_widget_render(UIWidget_t *w) {
   draw_rect_border(r, w->rect);
 
   /* Text */
-  int text_x = w->rect.x + 8;
-  int available_w = w->rect.w - 16; /* 8px padding each side */
+  int text_x = w->rect.x + g_layout_cfg.input_text_pad_x;
+  int available_w = w->rect.w - g_layout_cfg.input_text_pad_x * 2;
 
   /* Build display string: asterisks for masked fields, raw buf otherwise */
   char masked_buf[MAX_INPUT_LENGTH];
@@ -145,7 +145,7 @@ InputWidget_t *input_widget_create(const char *initial, TTF_Font *font, int w, C
     TTF_SizeUTF8(font, "Ag", NULL, &th);
 
   iw->base.rect.w = w;
-  iw->base.rect.h = th + 16;
+  iw->base.rect.h = th + g_layout_cfg.input_h_pad;
   iw->base.render = input_widget_render;
   iw->base.destroy = input_widget_destroy;
 

--- a/src/widgets/link.c
+++ b/src/widgets/link.c
@@ -2,9 +2,6 @@
 #include "globals.h"
 #include "graphics.h"
 
-#define LINK_PAD_X 10
-#define LINK_PAD_Y 2
-
 static void link_widget_render(UIWidget_t *w) {
   LinkWidget_t *lw = (LinkWidget_t *)w;
   SDL_Renderer *r = g_sdl_context->renderer;
@@ -17,8 +14,8 @@ static void link_widget_render(UIWidget_t *w) {
 
   TextWidget_t *tw = w->hovered ? lw->text_hovered : lw->text_normal;
   if (tw) {
-    tw->base.rect.x = w->rect.x + LINK_PAD_X;
-    tw->base.rect.y = w->rect.y + LINK_PAD_Y;
+    tw->base.rect.x = w->rect.x + g_layout_cfg.link_pad_x;
+    tw->base.rect.y = w->rect.y + g_layout_cfg.link_pad_y;
     ui_widget_render(&tw->base);
   }
 }
@@ -57,8 +54,8 @@ LinkWidget_t *link_widget_create(const char *text, const char *url, TTF_Font *fo
     return NULL;
   }
 
-  lw->base.rect.w = lw->text_normal->base.rect.w + LINK_PAD_X * 2;
-  lw->base.rect.h = lw->text_normal->base.rect.h + LINK_PAD_Y * 2;
+  lw->base.rect.w = lw->text_normal->base.rect.w + g_layout_cfg.link_pad_x * 2;
+  lw->base.rect.h = lw->text_normal->base.rect.h + g_layout_cfg.link_pad_y * 2;
 
   lw->base.render = link_widget_render;
   lw->base.destroy = link_widget_destroy;

--- a/tests/layout_cards.c
+++ b/tests/layout_cards.c
@@ -28,6 +28,12 @@ players_array[1].in = true;
 player_pos[1].x = 100;
 player_pos[1].y = 200;
 
+// layout_cards uses g_layout_cfg for card dimensions; set non-zero values
+// matching the defaults in layout.conf so rect.w assertions are meaningful.
+g_layout_cfg.card_w = 80;
+g_layout_cfg.card_h = 50;
+g_layout_cfg.card_padding = 10;
+
 // Before the fix this would loop forever; after the fix it returns immediately.
 layout_cards(card_context, players_array, player_pos);
 


### PR DESCRIPTION
Replace compile-time #defines (MARGIN, BUTTON_X_SPACING, CARD_W/H/PADDING,
CIRCLE_TIMER_R, MSG_PANEL_*, SETTINGS_INPUT_*, LINK_PAD_*, back_btn_size) and
hardcoded magic numbers in layout_compute() with a runtime LayoutConfig_t
struct loaded from data/layout.conf at startup. SIZEOF_STATUS_MSGS remains a
compile-time constant as it sizes static arrays.

    layout: move remaining hardcoded layout values into layout.conf

    Add 24 more fields to LayoutConfig_t covering: pot boundary, board y
offset, timer border thickness, indicator padding/min-radius, nameplate
    pad/radius, open-card pad, kick/ban button gaps, confirm-quit dialog
    padding, connect/settings screen button gaps, input field spacing,
version text offsets, checkbox padding, and button/input widget padding.