### PR TITLE
pokeval: fix compare_hands_wild tiebreaking for group-ranked hands

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,13 @@
     phase can still be buffered in the TCP socket when the game starts, causing
     an "Unrecognised opcode" error and a spurious disconnection
   * Move deckhandler and pokeval inline (no longer imported as meson subprojects)
+  * pokeval: fix compare_hands_wild tiebreaking for THREE_OF_A_KIND (and
+    FOUR_OF_A_KIND, FULL_HOUSE, FIVE_OF_A_KIND): the previous code compared raw
+    sorted face values, so a wild hand like J J 2 could lose to 7 7 7 when the
+    natural hand held higher kickers (K, Q) that sorted above the wild hand's
+    trip card; now uses rank-aware group-value comparison that correctly
+    identifies the effective triplet/quad/quint face regardless of which cards
+    are wild
   * bugfix: Window becomes unresponsive on systems where audio initialisation
     blocks (e.g. PulseAudio socket absent); run ma_engine_init on a background
     thread and fall back to silent (noDevice) mode on failure

--- a/src/pokeval/pokeval.c
+++ b/src/pokeval/pokeval.c
@@ -866,6 +866,29 @@ uint8_t POKEVAL_compare_hands_omaha(POKEVAL_NeedComparing *need_comparing, uint8
   return compare_hands_5(need_comparing, count);
 }
 
+// Returns the face value of the highest N-of-a-kind group in a wild hand.
+// Checks for a natural group of exactly `group_size` first, then falls back
+// to the highest non-wild face whose natural count plus available wilds
+// reaches `group_size`.
+static int get_group_value_wild(const POKEVAL_Hand_5 *hand, int32_t wild_face, int group_size) {
+  for (int i = 0; i < POKEVAL_HAND_SIZE; i++) {
+    int fv = hand->card[i].face_val;
+    if (fv != wild_face && count_face(hand, fv) == group_size)
+      return fv;
+  }
+  int n_wild = 0;
+  for (int i = 0; i < POKEVAL_HAND_SIZE; i++)
+    if (hand->card[i].face_val == wild_face) n_wild++;
+  int best = -1;
+  for (int i = 0; i < POKEVAL_HAND_SIZE; i++) {
+    int fv = hand->card[i].face_val;
+    if (fv == wild_face) continue;
+    if (count_face(hand, fv) + n_wild >= group_size && fv > best)
+      best = fv;
+  }
+  return best;
+}
+
 uint8_t POKEVAL_compare_hands_wild(POKEVAL_NeedComparing *need_comparing, uint8_t count,
                                    int32_t wild_face) {
   for (size_t i = 0; i < count; ++i)
@@ -893,10 +916,76 @@ uint8_t POKEVAL_compare_hands_wild(POKEVAL_NeedComparing *need_comparing, uint8_
       POKEVAL_Hand_5 b = current_hand;
       POKEVAL_sort_hand(&a);
       POKEVAL_sort_hand(&b);
-      int cmp = compare_high_cards(&a, &b);
-      if (cmp == 0) {
+
+      bool b_wins = false;
+      bool tie = false;
+
+      switch (rank) {
+      case POKEVAL_ROYAL_FLUSH:
+        tie = true;
+        break;
+      case POKEVAL_FIVE_OF_A_KIND: {
+        int av = get_group_value_wild(&a, wild_face, 5);
+        int bv = get_group_value_wild(&b, wild_face, 5);
+        if (av == bv) tie = true;
+        else b_wins = bv > av;
+        break;
+      }
+      case POKEVAL_FOUR_OF_A_KIND: {
+        int aq = get_group_value_wild(&a, wild_face, 4);
+        int bq = get_group_value_wild(&b, wild_face, 4);
+        if (aq != bq) {
+          b_wins = bq > aq;
+        } else {
+          int cmp = compare_high_cards(&a, &b);
+          if (cmp == 0) tie = true;
+          else if (cmp < 0) b_wins = true;
+        }
+        break;
+      }
+      case POKEVAL_FULL_HOUSE: {
+        int at = get_group_value_wild(&a, wild_face, 3);
+        int bt = get_group_value_wild(&b, wild_face, 3);
+        if (at != bt) {
+          b_wins = bt > at;
+        } else {
+          int ap = -1, bp = -1;
+          for (int j = 0; j < POKEVAL_HAND_SIZE; j++) {
+            int val = a.card[j].face_val;
+            if (val != at && val != wild_face && count_face(&a, val) == 2) { ap = val; break; }
+          }
+          for (int j = 0; j < POKEVAL_HAND_SIZE; j++) {
+            int val = b.card[j].face_val;
+            if (val != bt && val != wild_face && count_face(&b, val) == 2) { bp = val; break; }
+          }
+          if (ap == bp) tie = true;
+          else b_wins = bp > ap;
+        }
+        break;
+      }
+      case POKEVAL_THREE_OF_A_KIND: {
+        int at = get_group_value_wild(&a, wild_face, 3);
+        int bt = get_group_value_wild(&b, wild_face, 3);
+        if (at != bt) {
+          b_wins = bt > at;
+        } else {
+          int cmp = compare_high_cards(&a, &b);
+          if (cmp == 0) tie = true;
+          else if (cmp < 0) b_wins = true;
+        }
+        break;
+      }
+      default: {
+        int cmp = compare_high_cards(&a, &b);
+        if (cmp == 0) tie = true;
+        else if (cmp < 0) b_wins = true;
+        break;
+      }
+      }
+
+      if (tie) {
         winner_indices[num_winners++] = i;
-      } else if (cmp < 0) {
+      } else if (b_wins) {
         best_hand = current_hand;
         winner_indices[0] = i;
         num_winners = 1;

--- a/src/pokeval/tests/wild.c
+++ b/src/pokeval/tests/wild.c
@@ -242,4 +242,40 @@ _MAIN_HEAD_
   assert(rank == POKEVAL_STRAIGHT_FLUSH);
 }
 
+/* --- compare_hands_wild: trips comparison ---
+ * J J 2 3 4 (wild 2 = three Jacks) must beat 7 7 7 K Q (three Sevens) even
+ * though K Q sort higher than J in a raw high-card comparison.
+ * Regression test: compare_hands_wild must use rank-aware tiebreaking, not
+ * raw compare_high_cards, when both hands evaluate to the same rank.
+ *
+ * PAD_NULL_CARDS after the 5 real cards is required so that
+ * hand5_from_hand7_wild stops at n=5 and takes the direct copy path instead
+ * of the combo path, which would otherwise treat zero-initialized trailing
+ * slots as a phantom pair and inflate both hands to Full House. */
+{
+  POKEVAL_NeedComparing hands[2] = {
+    /* Hand 0: 7 7 7 K Q — three Sevens with high kickers */
+    {.id = 0,
+     .hand = {{{DH_CARD_SEVEN, DH_SUIT_HEARTS},
+               {DH_CARD_SEVEN, DH_SUIT_DIAMONDS},
+               {DH_CARD_SEVEN, DH_SUIT_SPADES},
+               {DH_CARD_KING, DH_SUIT_CLUBS},
+               {DH_CARD_QUEEN, DH_SUIT_CLUBS},
+               PAD_NULL_CARDS}}},
+    /* Hand 1: J J 2 3 4 — wild 2 fills the third Jack */
+    {.id = 1,
+     .hand = {{{DH_CARD_JACK, DH_SUIT_HEARTS},
+               {DH_CARD_JACK, DH_SUIT_DIAMONDS},
+               {DH_CARD_TWO, DH_SUIT_SPADES},
+               {DH_CARD_THREE, DH_SUIT_CLUBS},
+               {DH_CARD_FOUR, DH_SUIT_HEARTS},
+               PAD_NULL_CARDS}}},
+  };
+  uint8_t n_wins = POKEVAL_compare_hands_wild(hands, 2, DH_CARD_TWO);
+  fprintf(stderr, "wild trips compare (J J 2 3 4 vs 7 7 7 K Q): %d winner(s)\n", n_wins);
+  assert(n_wins == 1);
+  assert(!hands[0].won); /* three Sevens loses */
+  assert(hands[1].won);  /* three Jacks (wild) wins */
+}
+
 _MAIN_TAIL_


### PR DESCRIPTION
When two wild hands shared the same rank, compare_hands_wild fell back to a raw compare_high_cards on the sorted face values. This caused wrong results for THREE_OF_A_KIND (and FOUR_OF_A_KIND, FULL_HOUSE, FIVE_OF_A_KIND) whenever one hand's kickers happened to outrank the other hand's effective trips/quads: e.g. 7 7 7 K Q (three sevens, high kickers) incorrectly beat J J 2 (wild 2 = three Jacks) because K sorted above J.

Add get_group_value_wild() to find the effective group face value in a wild hand, and replace the flat tiebreak with a rank-aware switch mirroring the one already present in compare_hands_5.

Add a regression test to wild.c covering the exact scenario. The test also documents that PAD_NULL_CARDS is required after the 5 real cards in a POKEVAL_Hand_9 to prevent zero-initialized trailing slots from being counted as a phantom pair.