### PR TITLE
client,main: exit directly when window X is clicked from game lobby

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -108,6 +108,7 @@ typedef enum {
   GAME_SEL_ERROR = 0,
   GAME_SEL_SUCCESS = 1,
   GAME_SEL_BACK = 2,
+  GAME_SEL_QUIT = 3,
 } EGameSelResult_t;
 
 typedef enum {
@@ -459,7 +460,8 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
       switch (e.type) {
 
       case SDL_QUIT:
-        result = false;
+        SDL_PushEvent(&e);
+        result = GAME_SEL_QUIT;
         goto cleanup;
 
       case SDL_MOUSEBUTTONDOWN: {
@@ -468,7 +470,7 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
               confirm_quit(font->fonts[FONT_BOLD])) {
             SDL_Event quit = {.type = SDL_QUIT};
             SDL_PushEvent(&quit);
-            result = GAME_SEL_ERROR;
+            result = GAME_SEL_QUIT;
             goto cleanup;
           }
           if (back_img && SDL_PointInRect(&mouse_pos, &back_img->base.rect)) {
@@ -533,7 +535,7 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
           if (confirm_quit(font->fonts[FONT_BOLD])) {
             SDL_Event quit = {.type = SDL_QUIT};
             SDL_PushEvent(&quit);
-            result = GAME_SEL_ERROR;
+            result = GAME_SEL_QUIT;
             goto cleanup;
           }
           break;
@@ -2421,11 +2423,7 @@ bool get_socket_context_and_run_client(PlayerConfig_t *player_config, const CliA
         EGameSelResult_t sel = handle_game_selection(
             player_config, &socket_context, game_settings.client_id, &game_state, &client_state,
             sdl_context, font, &sound_context, links, path);
-        if (sel == GAME_SEL_BACK) {
-          went_back = true;
-          break;
-        }
-        if (sel == GAME_SEL_ERROR) {
+        if (sel == GAME_SEL_BACK || sel == GAME_SEL_ERROR || sel == GAME_SEL_QUIT) {
           went_back = true;
           break;
         }

--- a/src/main.c
+++ b/src/main.c
@@ -927,8 +927,12 @@ int main(int argc, char *argv[]) {
           get_socket_context_and_run_client(&player_config, &cli_args, host_str, port, &sdl_context,
                                             &font, &path, cli_args.test_mode, links, NULL);
       if (went_back) {
-        loop_to_connect = true;
-        first_connect = false;
+        SDL_Event peek;
+        SDL_PumpEvents();
+        if (SDL_PeepEvents(&peek, 1, SDL_PEEKEVENT, SDL_QUIT, SDL_QUIT) <= 0) {
+          loop_to_connect = true;
+          first_connect = false;
+        }
       }
     }
   }


### PR DESCRIPTION
When the window manager close button is clicked from the game lobby, SDL_QUIT was consumed without being re-queued, so the user was taken to the connect screen and had to click X a second time to exit.

Push SDL_QUIT back into the event queue when it fires in handle_game_selection. In main, use SDL_PeepEvents after get_socket_context_and_run_client returns to detect a pending quit and skip re-entering the connect screen loop.

The back button is unaffected: it does not push SDL_QUIT, so SDL_PeepEvents finds nothing and the connect screen appears as before.

Written by Claude, with Andy's permission