### PR TITLE
macos: cache Homebrew bottles between runs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,11 +26,19 @@ jobs:
           - macos-15
           - macos-14
     runs-on: ${{ matrix.os }}
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
     steps:
     - uses: actions/checkout@v6
+    - name: Cache Homebrew packages
+      uses: actions/cache@v5
+      with:
+        path: ~/Library/Caches/Homebrew
+        key: ${{ runner.os }}-${{ matrix.os }}-brew-${{ hashFiles('.github/workflows/macos.yml') }}
+        restore-keys: ${{ runner.os }}-${{ matrix.os }}-brew-
     - name: Install Dependencies
       run: |
-        brew update
         brew install \
           canfigger \
           gettext \


### PR DESCRIPTION
Add actions/cache for ~/Library/Caches/Homebrew so brew install skips re-downloading bottles on cache hits. Set HOMEBREW_NO_AUTO_UPDATE and HOMEBREW_NO_INSTALL_CLEANUP to suppress Homebrew's self-update overhead during install. Remove explicit brew update — the env var already prevents auto-update, and runner images ship with a current enough formula list.

Cache key includes matrix.os so macos-14 and macos-15 get separate caches, and hashFiles(macos.yml) invalidates on dep list changes.

Written by Claude, with Andy's permission

Maybe this will work @KaruroChori I started a PR a while back in your repo https://github.com/KaruroChori/vs-fltk/pull/35