### PR TITLE
util,dc_config: expand ~ in --server-conf path argument

### DIFF
--- a/src/dc_config.c
+++ b/src/dc_config.c
@@ -274,7 +274,7 @@ ServerConfig_t get_server_config(Path_t *path, const CliArgs_t *cli_args) {
       return config;
     }
   } else {
-    path->server_conf_name = dc_strdup(cli_args->server_conf);
+    path->server_conf_name = expand_tilde(cli_args->server_conf);
   }
 
   printf("Reading server config: %s\n", path->server_conf_name);

--- a/src/util.c
+++ b/src/util.c
@@ -30,6 +30,7 @@
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 
 #ifdef _WIN32
@@ -42,7 +43,6 @@
 // clang-format on
 #else
 #include <fcntl.h>
-#include <string.h>
 #include <unistd.h>
 #define PATH_SEP '/'
 #define mkdir(path, mode) mkdir(path, mode)
@@ -160,12 +160,21 @@ int make_directory_recursive(const char *path) {
   return 0;
 }
 
-void *calloc_wrap(const size_t n, const size_t size) {
+void *real_calloc_wrap(const size_t n, const size_t size, const char *func, int line) {
   void *ptr = calloc(n, size);
   if (ptr)
     return ptr;
 
-  perror("calloc");
+  fprintf(stderr, "calloc: %s in %s() at line %d\n", strerror(errno), func, line);
+  exit(EXIT_FAILURE);
+}
+
+void *real_malloc_wrap(const size_t size, const char *func, int line) {
+  void *ptr = malloc(size);
+  if (ptr)
+    return ptr;
+
+  fprintf(stderr, "malloc: %s in %s() at line %d\n", strerror(errno), func, line);
   exit(EXIT_FAILURE);
 }
 
@@ -215,10 +224,27 @@ char *dc_strdup(const char *s) {
     return NULL;
 
   size_t len = strlen(s) + 1;
-  char *copy = malloc(len);
-  if (!copy)
-    return NULL;
-
+  char *copy = malloc_wrap(len);
   memcpy(copy, s, len);
   return copy;
+}
+
+char *expand_tilde(const char *path) {
+  if (!path || path[0] != '~' || (path[1] != '/' && path[1] != '\0'))
+    return dc_strdup(path);
+
+#ifdef _WIN32
+  const char *home = getenv("USERPROFILE");
+#else
+  const char *home = getenv("HOME");
+#endif
+  if (!home)
+    return dc_strdup(path);
+
+  size_t home_len = strlen(home);
+  size_t path_len = strlen(path);
+  char *result = malloc_wrap(home_len + path_len);
+  memcpy(result, home, home_len);
+  memcpy(result + home_len, path + 1, path_len);
+  return result;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -53,7 +53,11 @@ EPathState check_pathname_state(const char *pathname);
 
 int make_directory_recursive(const char *path);
 
-void *calloc_wrap(const size_t n, const size_t size);
+void *real_calloc_wrap(const size_t n, const size_t size, const char *func, int line);
+void *real_malloc_wrap(const size_t size, const char *func, int line);
+
+#define calloc_wrap(n, size) real_calloc_wrap(n, size, __func__, __LINE__)
+#define malloc_wrap(size) real_malloc_wrap(size, __func__, __LINE__)
 
 void verbose_printf(const char *fmt, ...);
 
@@ -64,5 +68,7 @@ void parse_signed(const char *s, long minv, long maxv, long *out);
 void parse_unsigned(const char *s, unsigned long maxv, unsigned long *out);
 
 char *dc_strdup(const char *s);
+
+char *expand_tilde(const char *path);
 
 #endif


### PR DESCRIPTION
Bash does not perform tilde expansion on arguments passed with = (e.g. --server-conf=~/foo), so the literal ~ reached the program. Add expand_tilde() to util.c and use it when storing the --server-conf path.

Handles ~/... and bare ~ only; ~username is left as-is. Falls back to USERPROFILE on Windows.

Add malloc_wrap() alongside calloc_wrap(); both now report the call site (__func__ + __LINE__) and strerror(errno) on failure. dc_strdup() and expand_tilde() use malloc_wrap() so callers need not check for NULL.

Written by Claude, with Andy's permission