### PR TITLE
server: fix regression — broadcast "drew 0" on discard timeout

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
 - (in-progress)
+  * regression fix: when a player times out during the discard phase the status
+    message now correctly shows they drew 0 cards; the regression was introduced
+    in 2fd55fb when explicit timeout handling was added to handle_draw() but the
+    status broadcast was not carried over (#265)
   * Replace SDL2_net with tcpme (thin POSIX/Winsock wrapper)
   * Fix OpenBSD build (#270)
   * Bump GAME_PROTOCOL_VERSION from 9 to 10

--- a/src/server.c
+++ b/src/server.c
@@ -621,6 +621,7 @@ static ELoop_t handle_draw(ArgsBroadcastGameState_t *args, tcpme_socket_t sock, 
 
   DrawRequestMsg_t req;
   uint8_t buffer[32] = {0};
+  bool timed_out = false;
 
   uint32_t wait_ms = args->game_settings->action_timeout_ms;
   uint32_t start = SDL_GetTicks();
@@ -663,7 +664,8 @@ static ELoop_t handle_draw(ArgsBroadcastGameState_t *args, tcpme_socket_t sock, 
         printf("exceeded timeout threshold (%d): disconnecting %s\n", m,
                args->game_state->player[id].nick);
       }
-      return LOOP_CONTINUE;
+      timed_out = true;
+      break;
     }
 
     /* Payload buffer must fit both PING_RESPONSE (up to ~12 B) and
@@ -721,7 +723,7 @@ static ELoop_t handle_draw(ArgsBroadcastGameState_t *args, tcpme_socket_t sock, 
     send_new_hand(sock, &args->real_hand[id], MAX_HAND_SIZE);
   }
 
-  return LOOP_OK;
+  return timed_out ? LOOP_CONTINUE : LOOP_OK;
 }
 
 static EPlayerAction_t handle_check(PlayerActionMsg_t *action) {


### PR DESCRIPTION
Written by Claude, with Andy's permission.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Fixes #265