### PR TITLE
feat: add style config system (style.h/style.c)

### DIFF
--- a/data/layout.conf
+++ b/data/layout.conf
@@ -78,3 +78,20 @@ button_h_pad = 10
 [inputs]
 input_text_pad_x = 8
 input_h_pad = 16
+
+[styles]
+button_primary = black, yellow
+button_danger = white, red
+button_warn = brown, white
+button_cancel = white, gray
+text_on_dark = white
+text_on_light = black
+text_muted = lightgray
+link_normal = black
+link_hover = blue
+indicator_wild = purple, white
+indicator_game = orange, black
+timer_bg = table_green
+timer_elapsed = gold
+button_font = bold
+link_font = link

--- a/data/layout.conf
+++ b/data/layout.conf
@@ -71,27 +71,7 @@ lobby_kick_y_pct = 82
 kick_ban_btn_gap = 16
 game_kick_y_gap = 20
 
-[buttons]
-button_w_pad = 20
-button_h_pad = 10
-
 [inputs]
 input_text_pad_x = 8
 input_h_pad = 16
 
-[styles]
-button_primary = black, yellow
-button_danger = white, red
-button_warn = brown, white
-button_cancel = white, gray
-text_on_dark = white
-text_on_light = black
-text_muted = lightgray
-link_normal = black
-link_hover = blue
-indicator_wild = purple, white
-indicator_game = orange, black
-timer_bg = table_green
-timer_elapsed = gold
-button_font = bold
-link_font = link

--- a/src/client.c
+++ b/src/client.c
@@ -130,9 +130,9 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
   ButtonWidget_t *game_choice_button[MAX_CHOICES] = {0};
 
   // TRANSLATORS: Name of a poker variant. Usually left untranslated.
-  ButtonWidget_t *button_deuces_wild =
-      button_widget_create(_("Deuces Wild"), (EColor_t){COLOR_WHITE, COLOR_BROWN},
-                           font->fonts[FONT_BOLD], (SDL_Keycode)0);
+  ButtonWidget_t *button_deuces_wild = button_widget_create_colored(
+      _("Deuces Wild"), g_style_cfg.button_warn.bg, g_style_cfg.button_warn.fg,
+      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
 
   bool dealing = true;
 
@@ -145,9 +145,9 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
   ui_register(&registry, &button_deuces_wild->base);
 
   for (int i = 0; i < MAX_CHOICES; i++) {
-    game_choice_button[i] =
-        button_widget_create(game_choices[i].str, (EColor_t){COLOR_BLACK, COLOR_YELLOW},
-                             font->fonts[FONT_BOLD], (SDL_Keycode)0);
+    game_choice_button[i] = button_widget_create_colored(
+        game_choices[i].str, g_style_cfg.button_primary.bg, g_style_cfg.button_primary.fg,
+        font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
     ui_register(&registry, &game_choice_button[i]->base);
   }
 
@@ -175,21 +175,21 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
   bool table_needs_rebuild = true;
 
   TextWidget_t *connected_tw =
-      text_widget_create(_("Players"), font->fonts[FONT_BOLD], get_color(COLOR_BLACK));
+      text_widget_create(_("Players"), font->fonts[FONT_BOLD], g_style_cfg.text_on_light);
   ui_register(&registry, &connected_tw->base);
 
   TextWidget_t *dealer_label_tw =
-      text_widget_create(_("Dealer"), font->fonts[FONT_BOLD], get_color(COLOR_BLACK));
+      text_widget_create(_("Dealer"), font->fonts[FONT_BOLD], g_style_cfg.text_on_light);
   ui_register(&registry, &dealer_label_tw->base);
 
   TextWidget_t *ping_label_tw =
-      text_widget_create(_("Ping"), font->fonts[FONT_BOLD], get_color(COLOR_BLACK));
+      text_widget_create(_("Ping"), font->fonts[FONT_BOLD], g_style_cfg.text_on_light);
   ui_register(&registry, &ping_label_tw->base);
 
   char version_str[64] = {0};
   snprintf(version_str, sizeof(version_str), "Version " DEALERSCHOICE_VERSION);
   TextWidget_t *tw_version_lobby =
-      text_widget_create(version_str, font->fonts[FONT_VERSION], get_color(COLOR_WHITE));
+      text_widget_create(version_str, font->fonts[FONT_VERSION], g_style_cfg.text_on_dark);
   if (tw_version_lobby) {
     ui_widget_place(&tw_version_lobby->base, g_viewport.x + g_layout_cfg.margin,
                     g_viewport.y + g_viewport.h - tw_version_lobby->base.rect.h - g_layout_cfg.margin);
@@ -197,21 +197,23 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
   }
 
   TextWidget_t *waiting_players_tw = text_widget_create(
-      _("Waiting for more players..."), font->fonts[FONT_DEFAULT], get_color(COLOR_WHITE));
+      _("Waiting for more players..."), font->fonts[FONT_DEFAULT], g_style_cfg.text_on_dark);
   ui_register(&registry, &waiting_players_tw->base);
   waiting_players_tw->base.rect.x = g_center.x;
   waiting_players_tw->base.rect.y = g_layout.lobby.waiting_y;
 
   TextWidget_t *waiting_dealer_tw = text_widget_create(
-      _("Waiting for dealer to select game..."), font->fonts[FONT_DEFAULT], get_color(COLOR_WHITE));
+      _("Waiting for dealer to select game..."), font->fonts[FONT_DEFAULT], g_style_cfg.text_on_dark);
   ui_register(&registry, &waiting_dealer_tw->base);
   waiting_dealer_tw->base.rect.x = g_center.x;
   waiting_dealer_tw->base.rect.y = g_layout.lobby.waiting_y;
 
-  ButtonWidget_t *btn_kick = button_widget_create(_("Kick"), (EColor_t){COLOR_WHITE, COLOR_BROWN},
-                                                  font->fonts[FONT_BOLD], (SDL_Keycode)0);
-  ButtonWidget_t *btn_ban = button_widget_create(_("Ban"), (EColor_t){COLOR_WHITE, COLOR_BROWN},
-                                                 font->fonts[FONT_BOLD], (SDL_Keycode)0);
+  ButtonWidget_t *btn_kick = button_widget_create_colored(
+      _("Kick"), g_style_cfg.button_warn.bg, g_style_cfg.button_warn.fg,
+      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
+  ButtonWidget_t *btn_ban = button_widget_create_colored(
+      _("Ban"), g_style_cfg.button_warn.bg, g_style_cfg.button_warn.fg,
+      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
   btn_kick->base.rect.x = g_layout.lobby.kick_x;
   btn_kick->base.rect.y = g_layout.lobby.kick_y;
   btn_ban->base.rect.x = btn_kick->base.rect.x + btn_kick->base.rect.w + g_layout_cfg.kick_ban_btn_gap;
@@ -219,8 +221,9 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
   ui_register(&registry, &btn_kick->base);
   ui_register(&registry, &btn_ban->base);
 
-  ButtonWidget_t *btn_quit_lobby = button_widget_create("X", (EColor_t){COLOR_WHITE, COLOR_RED},
-                                                        font->fonts[FONT_BOLD], (SDL_Keycode)0);
+  ButtonWidget_t *btn_quit_lobby = button_widget_create_colored(
+      "X", g_style_cfg.button_danger.bg, g_style_cfg.button_danger.fg,
+      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
   if (btn_quit_lobby) {
     btn_quit_lobby->base.rect.x =
         g_viewport.x + g_viewport.w - btn_quit_lobby->base.rect.w - g_layout_cfg.margin;
@@ -998,18 +1001,20 @@ static void render_circle_timer(SDL_Renderer *renderer, SDL_Point center, float 
     }
   }
 
-  /* --- inner circle background (match table green) ----------------------- */
-  SDL_SetRenderDrawColor(renderer, 0, 125, 0, 255);
+  /* --- inner circle background ------------------------------------------- */
+  SDL_Color tbg = g_style_cfg.timer_bg;
+  SDL_SetRenderDrawColor(renderer, tbg.r, tbg.g, tbg.b, tbg.a);
   for (int y = cy - inner_r; y <= cy + inner_r; y++) {
     int dy = y - cy;
     int hw = (int)sqrtf((float)(inner_r * inner_r - dy * dy));
     SDL_RenderDrawLine(renderer, cx - hw, y, cx + hw, y);
   }
 
-  /* --- brown pie wedge (elapsed time, clockwise from 12 o'clock) --------- */
+  /* --- pie wedge (elapsed time, clockwise from 12 o'clock) --------------- */
   float sweep = (1.0f - fill_ratio) * 2.0f * (float)M_PI;
   if (sweep > 0.001f) {
-    SDL_SetRenderDrawColor(renderer, 240, 204, 48, 255); /* orange(ish) */
+    SDL_Color te = g_style_cfg.timer_elapsed;
+    SDL_SetRenderDrawColor(renderer, te.r, te.g, te.b, te.a);
     for (int y = cy - inner_r; y <= cy + inner_r; y++) {
       int dy = y - cy;
       int hw = (int)sqrtf((float)(inner_r * inner_r - dy * dy));
@@ -1177,14 +1182,14 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
 
   ButtonWidget_t *action_bw[MAX_ACTIONS];
   for (int i = 0; i < MAX_ACTIONS; i++) {
-    action_bw[i] =
-        button_widget_create(action_button_attrs[i].text, (EColor_t){COLOR_BLACK, COLOR_YELLOW},
-                             font->fonts[FONT_BOLD], action_button_attrs[i].key);
+    action_bw[i] = button_widget_create_colored(
+        action_button_attrs[i].text, g_style_cfg.button_primary.bg, g_style_cfg.button_primary.fg,
+        font->fonts[g_style_cfg.button_font], action_button_attrs[i].key);
   }
   layout_action_buttons(action_bw);
 
   TextWidget_t *discard_hint_tw = text_widget_create(
-      "You may only discard a maximum of 3 cards", font->fonts[FONT_BOLD], get_color(COLOR_WHITE));
+      "You may only discard a maximum of 3 cards", font->fonts[FONT_BOLD], g_style_cfg.text_on_dark);
   if (discard_hint_tw)
     ui_widget_place(&discard_hint_tw->base, g_layout.action_btn_x,
                     action_bw[DISCARD]->base.rect.y + g_layout_cfg.card_h);
@@ -1209,8 +1214,9 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
 
   for (size_t i = 0; i < n_bet_amounts; i++) {
     snprintf(amount_str[i], sizeof(amount_str[i]), "%" PRIu32, amount[i].value);
-    amount_bw[i] = button_widget_create(amount_str[i], (EColor_t){COLOR_WHITE, COLOR_BROWN},
-                                        font->fonts[FONT_BOLD], amount[i].hotkey);
+    amount_bw[i] = button_widget_create_colored(
+        amount_str[i], g_style_cfg.button_warn.bg, g_style_cfg.button_warn.fg,
+        font->fonts[g_style_cfg.button_font], amount[i].hotkey);
   }
   if (n_bet_amounts > 0) {
     amount_bw[0]->base.selected = true;
@@ -1222,12 +1228,15 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
 
   UIRegistry_t registry = {0};
 
-  ButtonWidget_t *game_btn_kick = button_widget_create(
-      _("Kick"), (EColor_t){COLOR_WHITE, COLOR_BROWN}, font->fonts[FONT_BOLD], (SDL_Keycode)0);
-  ButtonWidget_t *game_btn_ban = button_widget_create(
-      _("Ban"), (EColor_t){COLOR_WHITE, COLOR_BROWN}, font->fonts[FONT_BOLD], (SDL_Keycode)0);
-  ButtonWidget_t *game_btn_quit = button_widget_create("X", (EColor_t){COLOR_WHITE, COLOR_RED},
-                                                       font->fonts[FONT_BOLD], (SDL_Keycode)0);
+  ButtonWidget_t *game_btn_kick = button_widget_create_colored(
+      _("Kick"), g_style_cfg.button_warn.bg, g_style_cfg.button_warn.fg,
+      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
+  ButtonWidget_t *game_btn_ban = button_widget_create_colored(
+      _("Ban"), g_style_cfg.button_warn.bg, g_style_cfg.button_warn.fg,
+      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
+  ButtonWidget_t *game_btn_quit = button_widget_create_colored(
+      "X", g_style_cfg.button_danger.bg, g_style_cfg.button_danger.fg,
+      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
   game_btn_kick->base.rect.x = g_viewport.w / 10;
   /* Position above the status message panel, which starts at g_center.y */
   game_btn_kick->base.rect.y = g_center.y - game_btn_kick->base.rect.h - g_layout_cfg.game_kick_y_gap;
@@ -1239,8 +1248,9 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
   ui_register(&registry, &game_btn_ban->base);
   ui_register(&registry, &game_btn_quit->base);
 
-  Indicator_t *indicator_deuces_wild =
-      create_indicator(_("Deuces Wild"), font->fonts[FONT_BOLD], COLOR_PURPLE, COLOR_WHITE);
+  Indicator_t *indicator_deuces_wild = create_indicator_colored(
+      _("Deuces Wild"), font->fonts[FONT_BOLD],
+      g_style_cfg.indicator_wild.bg, g_style_cfg.indicator_wild.fg);
   ui_register(&registry, &indicator_deuces_wild->base);
 
   layout_deuces_wild_indicator(indicator_deuces_wild);
@@ -1265,7 +1275,7 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
   TextWidget_t *open_seat_tw[MAX_PLAYERS] = {0};
   for (int i = 0; i < MAX_PLAYERS; i++)
     open_seat_tw[i] =
-        text_widget_create("Open", font->fonts[FONT_DEFAULT], get_color(COLOR_LIGHTGRAY));
+        text_widget_create("Open", font->fonts[FONT_DEFAULT], g_style_cfg.text_muted);
 
   CoinInPot_t coin_in_pot[MAX_POT_COINS] = {0};
 
@@ -1274,7 +1284,7 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
   bool prev_winner_declared = game_state->winner_declared;
 
   for (int i = 0; i < SIZEOF_STATUS_MSGS; i++) {
-    status_tw[i] = text_widget_create(" ", font->fonts[FONT_STATUS_MSG], get_color(COLOR_BLACK));
+    status_tw[i] = text_widget_create(" ", font->fonts[FONT_STATUS_MSG], g_style_cfg.text_on_light);
     if (status_tw[i])
       ui_widget_place(&status_tw[i]->base, g_layout.msg_panel.x + g_layout_cfg.msg_panel_pad_x,
                       g_layout.msg_panel.y + g_layout_cfg.msg_panel_pad_y + i * (g_layout.status_line_h + 2));
@@ -1362,12 +1372,12 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
       char coins_str[24] = {0};
       snprintf(coins_str, sizeof coins_str, "%" PRId32, game_state->player[id].coins);
       game_nick_widgets[id] = nick_widget_create(game_state->player[id].nick, id,
-                                                 font->fonts[FONT_BOLD], get_color(COLOR_WHITE));
+                                                 font->fonts[FONT_BOLD], g_style_cfg.text_on_dark);
       game_nick_widgets[id]->highlight = (id == my_id);
       game_nick_widgets[id]->selectable = (game_state->player[my_id].is_admin && id != my_id);
       game_coin_widgets[id] = image_widget_from_texture(coin_tex_front, coin_px / 2, coin_px / 2);
       game_coins_tw[id] =
-          text_widget_create(coins_str, font->fonts[FONT_BOLD], get_color(COLOR_WHITE));
+          text_widget_create(coins_str, font->fonts[FONT_BOLD], g_style_cfg.text_on_dark);
       ui_register(&registry, &game_nick_widgets[id]->base);
       ui_register(&registry, &game_coin_widgets[id]->base);
       ui_register(&registry, &game_coins_tw[id]->base);
@@ -1514,8 +1524,9 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
     render_coin_animation(sdl_context->renderer, &coin_anim);
 
     if (!indicator_game_name && client_state.game_choice) {
-      indicator_game_name = create_indicator(client_state.game_choice->str, font->fonts[FONT_BOLD],
-                                             COLOR_ORANGE, COLOR_BLACK);
+      indicator_game_name = create_indicator_colored(
+          client_state.game_choice->str, font->fonts[FONT_BOLD],
+          g_style_cfg.indicator_game.bg, g_style_cfg.indicator_game.fg);
       ui_register(&registry, &indicator_game_name->base);
       layout_game_name_indicator(indicator_game_name);
     }
@@ -2080,8 +2091,9 @@ bool get_socket_context_and_run_client(PlayerConfig_t *player_config, const CliA
   ButtonWidget_t *btn_cancel = NULL;
   TextWidget_t *status_tw = NULL;
   if (sdl_context && font) {
-    btn_cancel = button_widget_create(_("Cancel"), (EColor_t){COLOR_BLACK, COLOR_YELLOW},
-                                      font->fonts[FONT_BOLD], SDLK_ESCAPE);
+    btn_cancel = button_widget_create_colored(
+        _("Cancel"), g_style_cfg.button_primary.bg, g_style_cfg.button_primary.fg,
+        font->fonts[g_style_cfg.button_font], SDLK_ESCAPE);
     if (btn_cancel) {
       btn_cancel->base.rect.x = g_center.x - btn_cancel->base.rect.w / 2;
       btn_cancel->base.rect.y = g_center.y + 60;
@@ -2090,7 +2102,7 @@ bool get_socket_context_and_run_client(PlayerConfig_t *player_config, const CliA
     snprintf(initial_status, sizeof(initial_status), _("Attempting connection to: %s... (%d/%d)"),
              host_str, 1, player_config->connect_attempts);
     status_tw =
-        text_widget_create(initial_status, font->fonts[FONT_DEFAULT], get_color(COLOR_WHITE));
+        text_widget_create(initial_status, font->fonts[FONT_DEFAULT], g_style_cfg.text_on_dark);
     if (status_tw) {
       status_tw->base.rect.x = 10;
       status_tw->base.rect.y = g_center.y;

--- a/src/client.c
+++ b/src/client.c
@@ -130,9 +130,8 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
   ButtonWidget_t *game_choice_button[MAX_CHOICES] = {0};
 
   // TRANSLATORS: Name of a poker variant. Usually left untranslated.
-  ButtonWidget_t *button_deuces_wild = button_widget_create_colored(
-      _("Deuces Wild"), g_style_cfg.button_warn.bg, g_style_cfg.button_warn.fg,
-      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
+  ButtonWidget_t *button_deuces_wild = button_widget_create_styled(
+      _("Deuces Wild"), &ROLE_ALT, font->fonts, (SDL_Keycode)0);
 
   bool dealing = true;
 
@@ -145,9 +144,8 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
   ui_register(&registry, &button_deuces_wild->base);
 
   for (int i = 0; i < MAX_CHOICES; i++) {
-    game_choice_button[i] = button_widget_create_colored(
-        game_choices[i].str, g_style_cfg.button_primary.bg, g_style_cfg.button_primary.fg,
-        font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
+    game_choice_button[i] = button_widget_create_styled(
+        game_choices[i].str, &ROLE_PRIMARY, font->fonts, (SDL_Keycode)0);
     ui_register(&registry, &game_choice_button[i]->base);
   }
 
@@ -175,21 +173,21 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
   bool table_needs_rebuild = true;
 
   TextWidget_t *connected_tw =
-      text_widget_create(_("Players"), font->fonts[FONT_BOLD], g_style_cfg.text_on_light);
+      text_widget_create(_("Players"), font->fonts[FONT_BOLD], DC_TEXT_ON_LIGHT);
   ui_register(&registry, &connected_tw->base);
 
   TextWidget_t *dealer_label_tw =
-      text_widget_create(_("Dealer"), font->fonts[FONT_BOLD], g_style_cfg.text_on_light);
+      text_widget_create(_("Dealer"), font->fonts[FONT_BOLD], DC_TEXT_ON_LIGHT);
   ui_register(&registry, &dealer_label_tw->base);
 
   TextWidget_t *ping_label_tw =
-      text_widget_create(_("Ping"), font->fonts[FONT_BOLD], g_style_cfg.text_on_light);
+      text_widget_create(_("Ping"), font->fonts[FONT_BOLD], DC_TEXT_ON_LIGHT);
   ui_register(&registry, &ping_label_tw->base);
 
   char version_str[64] = {0};
   snprintf(version_str, sizeof(version_str), "Version " DEALERSCHOICE_VERSION);
   TextWidget_t *tw_version_lobby =
-      text_widget_create(version_str, font->fonts[FONT_VERSION], g_style_cfg.text_on_dark);
+      text_widget_create(version_str, font->fonts[FONT_VERSION], DC_TEXT_ON_DARK);
   if (tw_version_lobby) {
     ui_widget_place(&tw_version_lobby->base, g_viewport.x + g_layout_cfg.margin,
                     g_viewport.y + g_viewport.h - tw_version_lobby->base.rect.h - g_layout_cfg.margin);
@@ -197,23 +195,21 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
   }
 
   TextWidget_t *waiting_players_tw = text_widget_create(
-      _("Waiting for more players..."), font->fonts[FONT_DEFAULT], g_style_cfg.text_on_dark);
+      _("Waiting for more players..."), font->fonts[FONT_DEFAULT], DC_TEXT_ON_DARK);
   ui_register(&registry, &waiting_players_tw->base);
   waiting_players_tw->base.rect.x = g_center.x;
   waiting_players_tw->base.rect.y = g_layout.lobby.waiting_y;
 
   TextWidget_t *waiting_dealer_tw = text_widget_create(
-      _("Waiting for dealer to select game..."), font->fonts[FONT_DEFAULT], g_style_cfg.text_on_dark);
+      _("Waiting for dealer to select game..."), font->fonts[FONT_DEFAULT], DC_TEXT_ON_DARK);
   ui_register(&registry, &waiting_dealer_tw->base);
   waiting_dealer_tw->base.rect.x = g_center.x;
   waiting_dealer_tw->base.rect.y = g_layout.lobby.waiting_y;
 
-  ButtonWidget_t *btn_kick = button_widget_create_colored(
-      _("Kick"), g_style_cfg.button_warn.bg, g_style_cfg.button_warn.fg,
-      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
-  ButtonWidget_t *btn_ban = button_widget_create_colored(
-      _("Ban"), g_style_cfg.button_warn.bg, g_style_cfg.button_warn.fg,
-      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
+  ButtonWidget_t *btn_kick = button_widget_create_styled(
+      _("Kick"), &ROLE_ALT, font->fonts, (SDL_Keycode)0);
+  ButtonWidget_t *btn_ban = button_widget_create_styled(
+      _("Ban"), &ROLE_ALT, font->fonts, (SDL_Keycode)0);
   btn_kick->base.rect.x = g_layout.lobby.kick_x;
   btn_kick->base.rect.y = g_layout.lobby.kick_y;
   btn_ban->base.rect.x = btn_kick->base.rect.x + btn_kick->base.rect.w + g_layout_cfg.kick_ban_btn_gap;
@@ -221,9 +217,8 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
   ui_register(&registry, &btn_kick->base);
   ui_register(&registry, &btn_ban->base);
 
-  ButtonWidget_t *btn_quit_lobby = button_widget_create_colored(
-      "X", g_style_cfg.button_danger.bg, g_style_cfg.button_danger.fg,
-      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
+  ButtonWidget_t *btn_quit_lobby = button_widget_create_styled(
+      "X", &ROLE_DANGER, font->fonts, (SDL_Keycode)0);
   if (btn_quit_lobby) {
     btn_quit_lobby->base.rect.x =
         g_viewport.x + g_viewport.w - btn_quit_lobby->base.rect.w - g_layout_cfg.margin;
@@ -470,7 +465,7 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
       case SDL_MOUSEBUTTONDOWN: {
         if (e.button.button == SDL_BUTTON_LEFT) {
           if (btn_quit_lobby && SDL_PointInRect(&mouse_pos, &btn_quit_lobby->base.rect) &&
-              confirm_quit(font->fonts[FONT_BOLD])) {
+              confirm_quit(font->fonts)) {
             SDL_Event quit = {.type = SDL_QUIT};
             SDL_PushEvent(&quit);
             result = GAME_SEL_QUIT;
@@ -535,7 +530,7 @@ static EGameSelResult_t handle_game_selection(const PlayerConfig_t *player_confi
         switch (e.key.keysym.sym) {
 
         case SDLK_ESCAPE:
-          if (confirm_quit(font->fonts[FONT_BOLD])) {
+          if (confirm_quit(font->fonts)) {
             SDL_Event quit = {.type = SDL_QUIT};
             SDL_PushEvent(&quit);
             result = GAME_SEL_QUIT;
@@ -1002,7 +997,7 @@ static void render_circle_timer(SDL_Renderer *renderer, SDL_Point center, float 
   }
 
   /* --- inner circle background ------------------------------------------- */
-  SDL_Color tbg = g_style_cfg.timer_bg;
+  SDL_Color tbg = DC_TIMER_BG;
   SDL_SetRenderDrawColor(renderer, tbg.r, tbg.g, tbg.b, tbg.a);
   for (int y = cy - inner_r; y <= cy + inner_r; y++) {
     int dy = y - cy;
@@ -1013,7 +1008,7 @@ static void render_circle_timer(SDL_Renderer *renderer, SDL_Point center, float 
   /* --- pie wedge (elapsed time, clockwise from 12 o'clock) --------------- */
   float sweep = (1.0f - fill_ratio) * 2.0f * (float)M_PI;
   if (sweep > 0.001f) {
-    SDL_Color te = g_style_cfg.timer_elapsed;
+    SDL_Color te = DC_TIMER_ELAPSED;
     SDL_SetRenderDrawColor(renderer, te.r, te.g, te.b, te.a);
     for (int y = cy - inner_r; y <= cy + inner_r; y++) {
       int dy = y - cy;
@@ -1182,14 +1177,13 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
 
   ButtonWidget_t *action_bw[MAX_ACTIONS];
   for (int i = 0; i < MAX_ACTIONS; i++) {
-    action_bw[i] = button_widget_create_colored(
-        action_button_attrs[i].text, g_style_cfg.button_primary.bg, g_style_cfg.button_primary.fg,
-        font->fonts[g_style_cfg.button_font], action_button_attrs[i].key);
+    action_bw[i] = button_widget_create_styled(
+        action_button_attrs[i].text, &ROLE_PRIMARY, font->fonts, action_button_attrs[i].key);
   }
   layout_action_buttons(action_bw);
 
   TextWidget_t *discard_hint_tw = text_widget_create(
-      "You may only discard a maximum of 3 cards", font->fonts[FONT_BOLD], g_style_cfg.text_on_dark);
+      "You may only discard a maximum of 3 cards", font->fonts[FONT_BOLD], DC_TEXT_ON_DARK);
   if (discard_hint_tw)
     ui_widget_place(&discard_hint_tw->base, g_layout.action_btn_x,
                     action_bw[DISCARD]->base.rect.y + g_layout_cfg.card_h);
@@ -1214,9 +1208,8 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
 
   for (size_t i = 0; i < n_bet_amounts; i++) {
     snprintf(amount_str[i], sizeof(amount_str[i]), "%" PRIu32, amount[i].value);
-    amount_bw[i] = button_widget_create_colored(
-        amount_str[i], g_style_cfg.button_warn.bg, g_style_cfg.button_warn.fg,
-        font->fonts[g_style_cfg.button_font], amount[i].hotkey);
+    amount_bw[i] = button_widget_create_styled(
+        amount_str[i], &ROLE_ALT, font->fonts, amount[i].hotkey);
   }
   if (n_bet_amounts > 0) {
     amount_bw[0]->base.selected = true;
@@ -1228,15 +1221,12 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
 
   UIRegistry_t registry = {0};
 
-  ButtonWidget_t *game_btn_kick = button_widget_create_colored(
-      _("Kick"), g_style_cfg.button_warn.bg, g_style_cfg.button_warn.fg,
-      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
-  ButtonWidget_t *game_btn_ban = button_widget_create_colored(
-      _("Ban"), g_style_cfg.button_warn.bg, g_style_cfg.button_warn.fg,
-      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
-  ButtonWidget_t *game_btn_quit = button_widget_create_colored(
-      "X", g_style_cfg.button_danger.bg, g_style_cfg.button_danger.fg,
-      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
+  ButtonWidget_t *game_btn_kick = button_widget_create_styled(
+      _("Kick"), &ROLE_ALT, font->fonts, (SDL_Keycode)0);
+  ButtonWidget_t *game_btn_ban = button_widget_create_styled(
+      _("Ban"), &ROLE_ALT, font->fonts, (SDL_Keycode)0);
+  ButtonWidget_t *game_btn_quit = button_widget_create_styled(
+      "X", &ROLE_DANGER, font->fonts, (SDL_Keycode)0);
   game_btn_kick->base.rect.x = g_viewport.w / 10;
   /* Position above the status message panel, which starts at g_center.y */
   game_btn_kick->base.rect.y = g_center.y - game_btn_kick->base.rect.h - g_layout_cfg.game_kick_y_gap;
@@ -1250,7 +1240,7 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
 
   Indicator_t *indicator_deuces_wild = create_indicator_colored(
       _("Deuces Wild"), font->fonts[FONT_BOLD],
-      g_style_cfg.indicator_wild.bg, g_style_cfg.indicator_wild.fg);
+      DC_INDICATOR_WILD_BG, DC_INDICATOR_WILD_FG);
   ui_register(&registry, &indicator_deuces_wild->base);
 
   layout_deuces_wild_indicator(indicator_deuces_wild);
@@ -1275,7 +1265,7 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
   TextWidget_t *open_seat_tw[MAX_PLAYERS] = {0};
   for (int i = 0; i < MAX_PLAYERS; i++)
     open_seat_tw[i] =
-        text_widget_create("Open", font->fonts[FONT_DEFAULT], g_style_cfg.text_muted);
+        text_widget_create("Open", font->fonts[FONT_DEFAULT], DC_TEXT_MUTED);
 
   CoinInPot_t coin_in_pot[MAX_POT_COINS] = {0};
 
@@ -1284,7 +1274,7 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
   bool prev_winner_declared = game_state->winner_declared;
 
   for (int i = 0; i < SIZEOF_STATUS_MSGS; i++) {
-    status_tw[i] = text_widget_create(" ", font->fonts[FONT_STATUS_MSG], g_style_cfg.text_on_light);
+    status_tw[i] = text_widget_create(" ", font->fonts[FONT_STATUS_MSG], DC_TEXT_ON_LIGHT);
     if (status_tw[i])
       ui_widget_place(&status_tw[i]->base, g_layout.msg_panel.x + g_layout_cfg.msg_panel_pad_x,
                       g_layout.msg_panel.y + g_layout_cfg.msg_panel_pad_y + i * (g_layout.status_line_h + 2));
@@ -1372,12 +1362,12 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
       char coins_str[24] = {0};
       snprintf(coins_str, sizeof coins_str, "%" PRId32, game_state->player[id].coins);
       game_nick_widgets[id] = nick_widget_create(game_state->player[id].nick, id,
-                                                 font->fonts[FONT_BOLD], g_style_cfg.text_on_dark);
+                                                 font->fonts[FONT_BOLD], DC_TEXT_ON_DARK);
       game_nick_widgets[id]->highlight = (id == my_id);
       game_nick_widgets[id]->selectable = (game_state->player[my_id].is_admin && id != my_id);
       game_coin_widgets[id] = image_widget_from_texture(coin_tex_front, coin_px / 2, coin_px / 2);
       game_coins_tw[id] =
-          text_widget_create(coins_str, font->fonts[FONT_BOLD], g_style_cfg.text_on_dark);
+          text_widget_create(coins_str, font->fonts[FONT_BOLD], DC_TEXT_ON_DARK);
       ui_register(&registry, &game_nick_widgets[id]->base);
       ui_register(&registry, &game_coin_widgets[id]->base);
       ui_register(&registry, &game_coins_tw[id]->base);
@@ -1526,7 +1516,7 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
     if (!indicator_game_name && client_state.game_choice) {
       indicator_game_name = create_indicator_colored(
           client_state.game_choice->str, font->fonts[FONT_BOLD],
-          g_style_cfg.indicator_game.bg, g_style_cfg.indicator_game.fg);
+          DC_INDICATOR_GAME_BG, DC_INDICATOR_GAME_FG);
       ui_register(&registry, &indicator_game_name->base);
       layout_game_name_indicator(indicator_game_name);
     }
@@ -1911,14 +1901,14 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
         running = false;
       } else if (event.type == SDL_MOUSEBUTTONDOWN && event.button.button == SDL_BUTTON_LEFT &&
                  SDL_PointInRect(&mouse_pos, &game_btn_quit->base.rect) &&
-                 confirm_quit(font->fonts[FONT_BOLD])) {
+                 confirm_quit(font->fonts)) {
         SDL_Event quit = {.type = SDL_QUIT};
         SDL_PushEvent(&quit);
         running = false;
       } else if (event.type == SDL_KEYDOWN) {
         switch (event.key.keysym.sym) {
         case SDLK_ESCAPE:
-          if (confirm_quit(font->fonts[FONT_BOLD])) {
+          if (confirm_quit(font->fonts)) {
             SDL_Event quit = {.type = SDL_QUIT};
             SDL_PushEvent(&quit);
             running = false;
@@ -2091,9 +2081,8 @@ bool get_socket_context_and_run_client(PlayerConfig_t *player_config, const CliA
   ButtonWidget_t *btn_cancel = NULL;
   TextWidget_t *status_tw = NULL;
   if (sdl_context && font) {
-    btn_cancel = button_widget_create_colored(
-        _("Cancel"), g_style_cfg.button_primary.bg, g_style_cfg.button_primary.fg,
-        font->fonts[g_style_cfg.button_font], SDLK_ESCAPE);
+    btn_cancel = button_widget_create_styled(
+        _("Cancel"), &ROLE_PRIMARY, font->fonts, SDLK_ESCAPE);
     if (btn_cancel) {
       btn_cancel->base.rect.x = g_center.x - btn_cancel->base.rect.w / 2;
       btn_cancel->base.rect.y = g_center.y + 60;
@@ -2102,7 +2091,7 @@ bool get_socket_context_and_run_client(PlayerConfig_t *player_config, const CliA
     snprintf(initial_status, sizeof(initial_status), _("Attempting connection to: %s... (%d/%d)"),
              host_str, 1, player_config->connect_attempts);
     status_tw =
-        text_widget_create(initial_status, font->fonts[FONT_DEFAULT], g_style_cfg.text_on_dark);
+        text_widget_create(initial_status, font->fonts[FONT_DEFAULT], DC_TEXT_ON_DARK);
     if (status_tw) {
       status_tw->base.rect.x = 10;
       status_tw->base.rect.y = g_center.y;

--- a/src/dc_config.c
+++ b/src/dc_config.c
@@ -139,8 +139,6 @@ const ConfigEntry layout_config_entries[] = {
     LC("version_x_offset",         "40",  version_x_offset),
     LC("version_y_offset",         "80",  version_y_offset),
     LC("checkbox_pad",             "16",  checkbox_pad),
-    LC("button_w_pad",             "20",  button_w_pad),
-    LC("button_h_pad",             "10",  button_h_pad),
     LC("input_text_pad_x",          "8",  input_text_pad_x),
     LC("input_h_pad",              "16",  input_h_pad),
     {0}};

--- a/src/dc_config.c
+++ b/src/dc_config.c
@@ -31,10 +31,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef _MSC_VER
-#define strcasecmp _stricmp
-#endif
-
 #include "dc_config.h"
 #include "layout.h"
 #include "util.h"

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -39,7 +39,7 @@
 
 void show_loading_screen(SDL_Renderer *renderer, TTF_Font *font, const char *message) {
   (void)renderer;
-  TextWidget_t *tw = text_widget_create(message, font, g_style_cfg.text_on_dark);
+  TextWidget_t *tw = text_widget_create(message, font, DC_TEXT_ON_DARK);
   if (!tw)
     return;
   int cx = 640 - tw->base.rect.w / 2;
@@ -83,18 +83,16 @@ void clear_screen(SDL_Renderer *renderer) {
   SDL_RenderClear(renderer);
 }
 
-bool confirm_quit(TTF_Font *font) {
-  if (!g_sdl_context || !font)
+bool confirm_quit(TTF_Font * const *fonts) {
+  if (!g_sdl_context || !fonts)
     return false;
 
   SDL_Renderer *r = g_sdl_context->renderer;
 
   TextWidget_t *msg_tw =
-      text_widget_create(_("Are you sure you want to quit?"), font, g_style_cfg.text_on_dark);
-  ButtonWidget_t *btn_cancel = button_widget_create_colored(
-      _("Cancel"), g_style_cfg.button_cancel.bg, g_style_cfg.button_cancel.fg, font, (SDL_Keycode)0);
-  ButtonWidget_t *btn_quit_w = button_widget_create_colored(
-      _("Quit"), g_style_cfg.button_danger.bg, g_style_cfg.button_danger.fg, font, (SDL_Keycode)0);
+      text_widget_create(_("Are you sure you want to quit?"), fonts[FONT_BOLD], DC_TEXT_ON_DARK);
+  ButtonWidget_t *btn_cancel = button_widget_create_styled(_("Cancel"), &ROLE_CANCEL, fonts, (SDL_Keycode)0);
+  ButtonWidget_t *btn_quit_w = button_widget_create_styled(_("Quit"), &ROLE_DANGER, fonts, (SDL_Keycode)0);
 
   if (!msg_tw || !btn_cancel || !btn_quit_w) {
     if (msg_tw)

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -31,6 +31,7 @@
 
 #include "graphics.h"
 #include "layout.h"
+#include "style.h"
 #include "translate.h"
 #include "ui_widget.h"
 #include "widgets/button.h"
@@ -38,7 +39,7 @@
 
 void show_loading_screen(SDL_Renderer *renderer, TTF_Font *font, const char *message) {
   (void)renderer;
-  TextWidget_t *tw = text_widget_create(message, font, get_color(COLOR_WHITE));
+  TextWidget_t *tw = text_widget_create(message, font, g_style_cfg.text_on_dark);
   if (!tw)
     return;
   int cx = 640 - tw->base.rect.w / 2;
@@ -89,11 +90,11 @@ bool confirm_quit(TTF_Font *font) {
   SDL_Renderer *r = g_sdl_context->renderer;
 
   TextWidget_t *msg_tw =
-      text_widget_create(_("Are you sure you want to quit?"), font, get_color(COLOR_WHITE));
-  ButtonWidget_t *btn_cancel =
-      button_widget_create(_("Cancel"), (EColor_t){COLOR_WHITE, COLOR_GRAY}, font, (SDL_Keycode)0);
-  ButtonWidget_t *btn_quit_w =
-      button_widget_create(_("Quit"), (EColor_t){COLOR_WHITE, COLOR_RED}, font, (SDL_Keycode)0);
+      text_widget_create(_("Are you sure you want to quit?"), font, g_style_cfg.text_on_dark);
+  ButtonWidget_t *btn_cancel = button_widget_create_colored(
+      _("Cancel"), g_style_cfg.button_cancel.bg, g_style_cfg.button_cancel.fg, font, (SDL_Keycode)0);
+  ButtonWidget_t *btn_quit_w = button_widget_create_colored(
+      _("Quit"), g_style_cfg.button_danger.bg, g_style_cfg.button_danger.fg, font, (SDL_Keycode)0);
 
   if (!msg_tw || !btn_cancel || !btn_quit_w) {
     if (msg_tw)

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -97,7 +97,7 @@ TTF_Font *open_font(const FontArgs_t *args);
 
 void clear_screen(SDL_Renderer *renderer);
 void draw_felt_background(SDL_Renderer *renderer, SDL_Texture *felt_tile);
-bool confirm_quit(TTF_Font *font);
+bool confirm_quit(TTF_Font * const *fonts);
 void draw_nameplate(SDL_Renderer *r, SDL_Rect rect, uint8_t alpha);
 SDL_Texture *create_vignette_texture(SDL_Renderer *renderer);
 

--- a/src/layout.h
+++ b/src/layout.h
@@ -86,8 +86,6 @@ typedef struct {
   int version_x_offset;
   int version_y_offset;
   int checkbox_pad;
-  int button_w_pad;
-  int button_h_pad;
   int input_text_pad_x;
   int input_h_pad;
 } LayoutConfig_t;

--- a/src/main.c
+++ b/src/main.c
@@ -54,12 +54,10 @@ enum { RUN_CLIENT = 20, RUN_SETTINGS = 21 };
 
 static int menu_display_connect(PlayerConfig_t *player_config, char *host_str, uint16_t *port,
                                 SdlContext_t *sdl_context, Font_t *font, LinkWidget_t **links) {
-  ButtonWidget_t *button_connect = button_widget_create_colored(
-      _("Connect"), g_style_cfg.button_primary.bg, g_style_cfg.button_primary.fg,
-      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
-  ButtonWidget_t *button_settings = button_widget_create_colored(
-      _("Settings"), g_style_cfg.button_primary.bg, g_style_cfg.button_primary.fg,
-      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
+  ButtonWidget_t *button_connect = button_widget_create_styled(
+      _("Connect"), &ROLE_PRIMARY, font->fonts, (SDL_Keycode)0);
+  ButtonWidget_t *button_settings = button_widget_create_styled(
+      _("Settings"), &ROLE_PRIMARY, font->fonts, (SDL_Keycode)0);
   UIRegistry_t reg = {0};
 
   button_connect->base.rect.x = g_layout.menu.margin_x;
@@ -91,16 +89,14 @@ static int menu_display_connect(PlayerConfig_t *player_config, char *host_str, u
   port_input->base.rect.y = host_input->base.rect.y + host_input->base.rect.h + g_layout_cfg.input_field_v_gap;
   ui_register(&reg, &port_input->base);
 
-  ButtonWidget_t *button_save = button_widget_create_colored(
-      _("Save"), g_style_cfg.button_primary.bg, g_style_cfg.button_primary.fg,
-      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
+  ButtonWidget_t *button_save = button_widget_create_styled(
+      _("Save"), &ROLE_PRIMARY, font->fonts, (SDL_Keycode)0);
   if (!button_save)
     goto err;
   ui_register(&reg, &button_save->base);
 
-  ButtonWidget_t *button_defaults = button_widget_create_colored(
-      _("Load Defaults"), g_style_cfg.button_primary.bg, g_style_cfg.button_primary.fg,
-      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
+  ButtonWidget_t *button_defaults = button_widget_create_styled(
+      _("Load Defaults"), &ROLE_PRIMARY, font->fonts, (SDL_Keycode)0);
   if (!button_defaults)
     goto err;
   ui_register(&reg, &button_defaults->base);
@@ -113,9 +109,8 @@ static int menu_display_connect(PlayerConfig_t *player_config, char *host_str, u
   button_defaults->base.rect.x = button_save->base.rect.x + button_save->base.rect.w + g_layout_cfg.connect_save_btn_gap;
   button_defaults->base.rect.y = button_save->base.rect.y;
 
-  ButtonWidget_t *btn_quit_connect = button_widget_create_colored(
-      "X", g_style_cfg.button_danger.bg, g_style_cfg.button_danger.fg,
-      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
+  ButtonWidget_t *btn_quit_connect = button_widget_create_styled(
+      "X", &ROLE_DANGER, font->fonts, (SDL_Keycode)0);
   if (btn_quit_connect) {
     btn_quit_connect->base.rect.x =
         g_viewport.x + g_viewport.w - btn_quit_connect->base.rect.w - g_layout_cfg.margin;
@@ -134,19 +129,19 @@ static int menu_display_connect(PlayerConfig_t *player_config, char *host_str, u
   layout_links(links, LINK_DEFS_COUNT);
 
   TextWidget_t *tw_title = text_widget_create(DEALERSCHOICE_FORMAL_NAME, font->fonts[FONT_TITLE],
-                                              g_style_cfg.text_on_light);
+                                              DC_TEXT_ON_LIGHT);
   if (tw_title)
     ui_widget_place(&tw_title->base, g_layout.menu.title_x, g_layout.menu.title_y);
 
   char version[64] = {0};
   snprintf(version, sizeof(version), "Version " DEALERSCHOICE_VERSION);
   TextWidget_t *tw_version =
-      text_widget_create(version, font->fonts[FONT_VERSION], g_style_cfg.text_on_dark);
+      text_widget_create(version, font->fonts[FONT_VERSION], DC_TEXT_ON_DARK);
   if (tw_version)
     ui_widget_place(&tw_version->base, g_layout.menu.title_x + g_layout_cfg.version_x_offset, g_layout.menu.title_y + g_layout_cfg.version_y_offset);
 
   TextWidget_t *tw_nick =
-      text_widget_create(player_config->nick, font->fonts[FONT_DEFAULT], g_style_cfg.text_on_light);
+      text_widget_create(player_config->nick, font->fonts[FONT_DEFAULT], DC_TEXT_ON_LIGHT);
   if (tw_nick)
     ui_widget_place(&tw_nick->base, input_nick_pos.x, input_nick_pos.y);
 
@@ -169,7 +164,7 @@ static int menu_display_connect(PlayerConfig_t *player_config, char *host_str, u
         running = false;
       } else if (e.type == SDL_MOUSEBUTTONDOWN) {
         if (btn_quit_connect && SDL_PointInRect(&mouse_pos, &btn_quit_connect->base.rect) &&
-            confirm_quit(font->fonts[FONT_BOLD])) {
+            confirm_quit(font->fonts)) {
           SDL_Event quit = {.type = SDL_QUIT};
           SDL_PushEvent(&quit);
           running = false;
@@ -207,7 +202,7 @@ static int menu_display_connect(PlayerConfig_t *player_config, char *host_str, u
       } else if (e.type == SDL_KEYDOWN) {
         switch (e.key.keysym.sym) {
         case SDLK_ESCAPE:
-          if (confirm_quit(font->fonts[FONT_BOLD])) {
+          if (confirm_quit(font->fonts)) {
             SDL_Event quit = {.type = SDL_QUIT};
             SDL_PushEvent(&quit);
             running = false;
@@ -427,9 +422,8 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
       text_input_indices[n_ti++] = i;
   int focused_slot = 0; /* index into text_input_indices */
 
-  ButtonWidget_t *btn_save = button_widget_create_colored(
-      _("Save"), g_style_cfg.button_primary.bg, g_style_cfg.button_primary.fg,
-      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
+  ButtonWidget_t *btn_save = button_widget_create_styled(
+      _("Save"), &ROLE_PRIMARY, font->fonts, (SDL_Keycode)0);
   if (!btn_save) {
     ui_destroy_all(&reg);
     return;
@@ -438,9 +432,8 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
   btn_save->base.rect.y = g_layout.menu.settings_save_y;
   ui_register(&reg, &btn_save->base);
 
-  ButtonWidget_t *btn_defaults = button_widget_create_colored(
-      _("Load Defaults"), g_style_cfg.button_primary.bg, g_style_cfg.button_primary.fg,
-      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
+  ButtonWidget_t *btn_defaults = button_widget_create_styled(
+      _("Load Defaults"), &ROLE_PRIMARY, font->fonts, (SDL_Keycode)0);
   if (!btn_defaults) {
     ui_destroy_all(&reg);
     return;
@@ -449,9 +442,8 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
   btn_defaults->base.rect.y = btn_save->base.rect.y;
   ui_register(&reg, &btn_defaults->base);
 
-  ButtonWidget_t *btn_quit_settings = button_widget_create_colored(
-      "X", g_style_cfg.button_danger.bg, g_style_cfg.button_danger.fg,
-      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
+  ButtonWidget_t *btn_quit_settings = button_widget_create_styled(
+      "X", &ROLE_DANGER, font->fonts, (SDL_Keycode)0);
   if (btn_quit_settings) {
     btn_quit_settings->base.rect.x =
         g_viewport.x + g_viewport.w - btn_quit_settings->base.rect.w - g_layout_cfg.margin;
@@ -462,7 +454,7 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
   Uint32 anim_start = SDL_GetTicks();
 
   TextWidget_t *tw_settings_title =
-      text_widget_create(_("Settings"), font->fonts[FONT_TITLE], g_style_cfg.text_on_light);
+      text_widget_create(_("Settings"), font->fonts[FONT_TITLE], DC_TEXT_ON_LIGHT);
   if (tw_settings_title)
     ui_widget_place(&tw_settings_title->base, g_layout.menu.title_x, g_layout.menu.title_y);
 
@@ -478,7 +470,7 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
       int row = (int)(rpos / 2);
       int lx = (col == 0) ? x_left : x_right;
       tw_labels[i] = text_widget_create(player_config_entries[i].key, font->fonts[FONT_DEFAULT],
-                                        g_style_cfg.text_on_light);
+                                        DC_TEXT_ON_LIGHT);
       if (tw_labels[i])
         ui_widget_place(&tw_labels[i]->base, lx, row_y[row]);
       rpos++;
@@ -508,7 +500,7 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
         running = false;
       } else if (e.type == SDL_MOUSEBUTTONDOWN && e.button.button == SDL_BUTTON_LEFT) {
         if (btn_quit_settings && SDL_PointInRect(&mouse_pos, &btn_quit_settings->base.rect) &&
-            confirm_quit(font->fonts[FONT_BOLD])) {
+            confirm_quit(font->fonts)) {
           SDL_Event quit = {.type = SDL_QUIT};
           SDL_PushEvent(&quit);
           running = false;
@@ -559,7 +551,7 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
           running = false;
           break;
         case SDLK_ESCAPE:
-          if (confirm_quit(font->fonts[FONT_BOLD])) {
+          if (confirm_quit(font->fonts)) {
             SDL_Event quit = {.type = SDL_QUIT};
             SDL_PushEvent(&quit);
             running = false;
@@ -882,7 +874,6 @@ int main(int argc, char *argv[]) {
   }
 
   g_layout_cfg = get_layout_config(path.data);
-  g_style_cfg = get_style_config(path.data);
   layout_init(TTF_FontHeight(font.fonts[FONT_STATUS_MSG]));
 
   PlayerConfig_t player_config = get_player_config();
@@ -906,7 +897,7 @@ int main(int argc, char *argv[]) {
 
   LinkWidget_t *links[LINK_DEFS_COUNT];
   for (size_t i = 0; i < LINK_DEFS_COUNT; i++)
-    links[i] = link_widget_create(_(LINK_DEFS[i].text), LINK_DEFS[i].url, font.fonts[g_style_cfg.link_font]);
+    links[i] = link_widget_create(_(LINK_DEFS[i].text), LINK_DEFS[i].url, font.fonts[FONT_LINK]);
   layout_links(links, LINK_DEFS_COUNT);
 
   char host_str[MAX_INPUT_LENGTH] = {0};

--- a/src/main.c
+++ b/src/main.c
@@ -54,10 +54,12 @@ enum { RUN_CLIENT = 20, RUN_SETTINGS = 21 };
 
 static int menu_display_connect(PlayerConfig_t *player_config, char *host_str, uint16_t *port,
                                 SdlContext_t *sdl_context, Font_t *font, LinkWidget_t **links) {
-  ButtonWidget_t *button_connect = button_widget_create(
-      _("Connect"), (EColor_t){COLOR_BLACK, COLOR_YELLOW}, font->fonts[FONT_BOLD], (SDL_Keycode)0);
-  ButtonWidget_t *button_settings = button_widget_create(
-      _("Settings"), (EColor_t){COLOR_BLACK, COLOR_YELLOW}, font->fonts[FONT_BOLD], (SDL_Keycode)0);
+  ButtonWidget_t *button_connect = button_widget_create_colored(
+      _("Connect"), g_style_cfg.button_primary.bg, g_style_cfg.button_primary.fg,
+      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
+  ButtonWidget_t *button_settings = button_widget_create_colored(
+      _("Settings"), g_style_cfg.button_primary.bg, g_style_cfg.button_primary.fg,
+      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
   UIRegistry_t reg = {0};
 
   button_connect->base.rect.x = g_layout.menu.margin_x;
@@ -89,15 +91,16 @@ static int menu_display_connect(PlayerConfig_t *player_config, char *host_str, u
   port_input->base.rect.y = host_input->base.rect.y + host_input->base.rect.h + g_layout_cfg.input_field_v_gap;
   ui_register(&reg, &port_input->base);
 
-  ButtonWidget_t *button_save = button_widget_create(
-      _("Save"), (EColor_t){COLOR_BLACK, COLOR_YELLOW}, font->fonts[FONT_BOLD], (SDL_Keycode)0);
+  ButtonWidget_t *button_save = button_widget_create_colored(
+      _("Save"), g_style_cfg.button_primary.bg, g_style_cfg.button_primary.fg,
+      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
   if (!button_save)
     goto err;
   ui_register(&reg, &button_save->base);
 
-  ButtonWidget_t *button_defaults =
-      button_widget_create(_("Load Defaults"), (EColor_t){COLOR_BLACK, COLOR_YELLOW},
-                           font->fonts[FONT_BOLD], (SDL_Keycode)0);
+  ButtonWidget_t *button_defaults = button_widget_create_colored(
+      _("Load Defaults"), g_style_cfg.button_primary.bg, g_style_cfg.button_primary.fg,
+      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
   if (!button_defaults)
     goto err;
   ui_register(&reg, &button_defaults->base);
@@ -110,8 +113,9 @@ static int menu_display_connect(PlayerConfig_t *player_config, char *host_str, u
   button_defaults->base.rect.x = button_save->base.rect.x + button_save->base.rect.w + g_layout_cfg.connect_save_btn_gap;
   button_defaults->base.rect.y = button_save->base.rect.y;
 
-  ButtonWidget_t *btn_quit_connect = button_widget_create("X", (EColor_t){COLOR_WHITE, COLOR_RED},
-                                                          font->fonts[FONT_BOLD], (SDL_Keycode)0);
+  ButtonWidget_t *btn_quit_connect = button_widget_create_colored(
+      "X", g_style_cfg.button_danger.bg, g_style_cfg.button_danger.fg,
+      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
   if (btn_quit_connect) {
     btn_quit_connect->base.rect.x =
         g_viewport.x + g_viewport.w - btn_quit_connect->base.rect.w - g_layout_cfg.margin;
@@ -130,19 +134,19 @@ static int menu_display_connect(PlayerConfig_t *player_config, char *host_str, u
   layout_links(links, LINK_DEFS_COUNT);
 
   TextWidget_t *tw_title = text_widget_create(DEALERSCHOICE_FORMAL_NAME, font->fonts[FONT_TITLE],
-                                              get_color(COLOR_BLACK));
+                                              g_style_cfg.text_on_light);
   if (tw_title)
     ui_widget_place(&tw_title->base, g_layout.menu.title_x, g_layout.menu.title_y);
 
   char version[64] = {0};
   snprintf(version, sizeof(version), "Version " DEALERSCHOICE_VERSION);
   TextWidget_t *tw_version =
-      text_widget_create(version, font->fonts[FONT_VERSION], get_color(COLOR_WHITE));
+      text_widget_create(version, font->fonts[FONT_VERSION], g_style_cfg.text_on_dark);
   if (tw_version)
     ui_widget_place(&tw_version->base, g_layout.menu.title_x + g_layout_cfg.version_x_offset, g_layout.menu.title_y + g_layout_cfg.version_y_offset);
 
   TextWidget_t *tw_nick =
-      text_widget_create(player_config->nick, font->fonts[FONT_DEFAULT], get_color(COLOR_BLACK));
+      text_widget_create(player_config->nick, font->fonts[FONT_DEFAULT], g_style_cfg.text_on_light);
   if (tw_nick)
     ui_widget_place(&tw_nick->base, input_nick_pos.x, input_nick_pos.y);
 
@@ -423,8 +427,9 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
       text_input_indices[n_ti++] = i;
   int focused_slot = 0; /* index into text_input_indices */
 
-  ButtonWidget_t *btn_save = button_widget_create(_("Save"), (EColor_t){COLOR_BLACK, COLOR_YELLOW},
-                                                  font->fonts[FONT_BOLD], (SDL_Keycode)0);
+  ButtonWidget_t *btn_save = button_widget_create_colored(
+      _("Save"), g_style_cfg.button_primary.bg, g_style_cfg.button_primary.fg,
+      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
   if (!btn_save) {
     ui_destroy_all(&reg);
     return;
@@ -433,9 +438,9 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
   btn_save->base.rect.y = g_layout.menu.settings_save_y;
   ui_register(&reg, &btn_save->base);
 
-  ButtonWidget_t *btn_defaults =
-      button_widget_create(_("Load Defaults"), (EColor_t){COLOR_BLACK, COLOR_YELLOW},
-                           font->fonts[FONT_BOLD], (SDL_Keycode)0);
+  ButtonWidget_t *btn_defaults = button_widget_create_colored(
+      _("Load Defaults"), g_style_cfg.button_primary.bg, g_style_cfg.button_primary.fg,
+      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
   if (!btn_defaults) {
     ui_destroy_all(&reg);
     return;
@@ -444,8 +449,9 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
   btn_defaults->base.rect.y = btn_save->base.rect.y;
   ui_register(&reg, &btn_defaults->base);
 
-  ButtonWidget_t *btn_quit_settings = button_widget_create("X", (EColor_t){COLOR_WHITE, COLOR_RED},
-                                                           font->fonts[FONT_BOLD], (SDL_Keycode)0);
+  ButtonWidget_t *btn_quit_settings = button_widget_create_colored(
+      "X", g_style_cfg.button_danger.bg, g_style_cfg.button_danger.fg,
+      font->fonts[g_style_cfg.button_font], (SDL_Keycode)0);
   if (btn_quit_settings) {
     btn_quit_settings->base.rect.x =
         g_viewport.x + g_viewport.w - btn_quit_settings->base.rect.w - g_layout_cfg.margin;
@@ -456,7 +462,7 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
   Uint32 anim_start = SDL_GetTicks();
 
   TextWidget_t *tw_settings_title =
-      text_widget_create(_("Settings"), font->fonts[FONT_TITLE], get_color(COLOR_BLACK));
+      text_widget_create(_("Settings"), font->fonts[FONT_TITLE], g_style_cfg.text_on_light);
   if (tw_settings_title)
     ui_widget_place(&tw_settings_title->base, g_layout.menu.title_x, g_layout.menu.title_y);
 
@@ -472,7 +478,7 @@ static void menu_display_settings(PlayerConfig_t *player_config, SdlContext_t *s
       int row = (int)(rpos / 2);
       int lx = (col == 0) ? x_left : x_right;
       tw_labels[i] = text_widget_create(player_config_entries[i].key, font->fonts[FONT_DEFAULT],
-                                        get_color(COLOR_BLACK));
+                                        g_style_cfg.text_on_light);
       if (tw_labels[i])
         ui_widget_place(&tw_labels[i]->base, lx, row_y[row]);
       rpos++;
@@ -876,6 +882,7 @@ int main(int argc, char *argv[]) {
   }
 
   g_layout_cfg = get_layout_config(path.data);
+  g_style_cfg = get_style_config(path.data);
   layout_init(TTF_FontHeight(font.fonts[FONT_STATUS_MSG]));
 
   PlayerConfig_t player_config = get_player_config();
@@ -899,7 +906,7 @@ int main(int argc, char *argv[]) {
 
   LinkWidget_t *links[LINK_DEFS_COUNT];
   for (size_t i = 0; i < LINK_DEFS_COUNT; i++)
-    links[i] = link_widget_create(_(LINK_DEFS[i].text), LINK_DEFS[i].url, font.fonts[FONT_LINK]);
+    links[i] = link_widget_create(_(LINK_DEFS[i].text), LINK_DEFS[i].url, font.fonts[g_style_cfg.link_font]);
   layout_links(links, LINK_DEFS_COUNT);
 
   char host_str[MAX_INPUT_LENGTH] = {0};

--- a/src/meson.build
+++ b/src/meson.build
@@ -27,6 +27,7 @@ shared_src = files(
   'net.c',
   'protobuf/netpoker.pb-c.c',
   'server.c',
+  'style.c',
   'ui_widget.c',
   'util.c',
 )

--- a/src/style.c
+++ b/src/style.c
@@ -26,142 +26,25 @@
 
 */
 
-#include <canfigger.h>
-#include <stdio.h>
-#include <string.h>
-
 #include "graphics.h"
 #include "style.h"
-#include "util.h"
-
-StyleConfig_t g_style_cfg;
-
-static const struct {
-  const char *name;
-  SDL_Color color;
-} color_lookup[] = {
-    {"white",       {255, 255, 255, 255}},
-    {"lightgray",   {200, 200, 200, 255}},
-    {"gray",        {128, 128, 128, 255}},
-    {"darkgray",    { 64,  64,  64, 255}},
-    {"black",       {  0,   0,   0, 255}},
-    {"red",         {255,   0,   0, 255}},
-    {"green",       {  0, 255,   0, 255}},
-    {"table_green", {  0, 125,   0, 255}},
-    {"blue",        {  0,   0, 255, 255}},
-    {"yellow",      {255, 255,   0, 255}},
-    {"cyan",        {  0, 255, 255, 255}},
-    {"magenta",     {255,   0, 255, 255}},
-    {"orange",      {255, 165,   0, 255}},
-    {"gold",        {240, 204,  48, 255}},
-    {"purple",      {128,   0, 128, 255}},
-    {"brown",       {165,  42,  42, 255}},
-    {"pink",        {255, 192, 203, 255}},
-    {"teal",        {  0, 128, 128, 255}},
-};
-
-static const struct {
-  const char *name;
-  int idx;
-} font_lookup[] = {
-    {"card",         FONT_CARD},
-    {"default",      FONT_DEFAULT},
-    {"default_bold", FONT_DEFAULT_BOLD},
-    {"bold",         FONT_BOLD},
-    {"link",         FONT_LINK},
-    {"status_msg",   FONT_STATUS_MSG},
-    {"title",        FONT_TITLE},
-    {"version",      FONT_VERSION},
-    {"wild_select",  FONT_WILD_SELECT},
-};
-
-static SDL_Color parse_color(const char *s) {
-  if (!s || !*s)
-    return (SDL_Color){0, 0, 0, 255};
-  if (s[0] == '#') {
-    unsigned r, g, b, a = 255;
-    if (sscanf(s + 1, "%02x%02x%02x%02x", &r, &g, &b, &a) >= 3)
-      return (SDL_Color){(Uint8)r, (Uint8)g, (Uint8)b, (Uint8)a};
-  }
-  for (size_t i = 0; i < ARRAY_SIZE(color_lookup); i++)
-    if (strcasecmp(s, color_lookup[i].name) == 0)
-      return color_lookup[i].color;
-  SDL_Log("style: unknown color '%s'", s);
-  return (SDL_Color){0, 0, 0, 255};
-}
-
-static int parse_font(const char *s) {
-  if (!s || !*s)
-    return FONT_BOLD;
-  for (size_t i = 0; i < ARRAY_SIZE(font_lookup); i++)
-    if (strcasecmp(s, font_lookup[i].name) == 0)
-      return font_lookup[i].idx;
-  SDL_Log("style: unknown font '%s'", s);
-  return FONT_BOLD;
-}
-
-typedef enum { STYLE_COLOR, STYLE_PAIR, STYLE_FONT } FieldType_t;
 
 // clang-format off
-static const struct {
-  const char  *key;
-  FieldType_t  type;
-  size_t       offset;
-} style_fields[] = {
-  {"button_primary",  STYLE_PAIR,  offsetof(StyleConfig_t, button_primary)},
-  {"button_danger",   STYLE_PAIR,  offsetof(StyleConfig_t, button_danger)},
-  {"button_warn",     STYLE_PAIR,  offsetof(StyleConfig_t, button_warn)},
-  {"button_cancel",   STYLE_PAIR,  offsetof(StyleConfig_t, button_cancel)},
-  {"indicator_wild",  STYLE_PAIR,  offsetof(StyleConfig_t, indicator_wild)},
-  {"indicator_game",  STYLE_PAIR,  offsetof(StyleConfig_t, indicator_game)},
-  {"text_on_dark",    STYLE_COLOR, offsetof(StyleConfig_t, text_on_dark)},
-  {"text_on_light",   STYLE_COLOR, offsetof(StyleConfig_t, text_on_light)},
-  {"text_muted",      STYLE_COLOR, offsetof(StyleConfig_t, text_muted)},
-  {"link_normal",     STYLE_COLOR, offsetof(StyleConfig_t, link_normal)},
-  {"link_hover",      STYLE_COLOR, offsetof(StyleConfig_t, link_hover)},
-  {"timer_bg",        STYLE_COLOR, offsetof(StyleConfig_t, timer_bg)},
-  {"timer_elapsed",   STYLE_COLOR, offsetof(StyleConfig_t, timer_elapsed)},
-  {"button_font",     STYLE_FONT,  offsetof(StyleConfig_t, button_font)},
-  {"link_font",       STYLE_FONT,  offsetof(StyleConfig_t, link_font)},
-};
+const ButtonRole_t ROLE_PRIMARY = { {  0,   0,   0, 255}, {255, 255,   0, 255}, FONT_BOLD, 20, 10 };
+const ButtonRole_t ROLE_DANGER  = { {255, 255, 255, 255}, {255,   0,   0, 255}, FONT_BOLD, 20, 10 };
+const ButtonRole_t ROLE_ALT    = { {255, 255, 255, 255}, {165,  42,  42, 255}, FONT_BOLD, 20, 10 };
+const ButtonRole_t ROLE_CANCEL  = { {255, 255, 255, 255}, {128, 128, 128, 255}, FONT_BOLD, 20, 10 };
+
+const SDL_Color DC_INDICATOR_WILD_BG = {128,   0, 128, 255};
+const SDL_Color DC_INDICATOR_WILD_FG = {255, 255, 255, 255};
+const SDL_Color DC_INDICATOR_GAME_BG = {255, 165,   0, 255};
+const SDL_Color DC_INDICATOR_GAME_FG = {  0,   0,   0, 255};
+
+const SDL_Color DC_TEXT_ON_DARK  = {255, 255, 255, 255};
+const SDL_Color DC_TEXT_ON_LIGHT = {  0,   0,   0, 255};
+const SDL_Color DC_TEXT_MUTED    = {200, 200, 200, 255};
+const SDL_Color DC_LINK_NORMAL   = {  0,   0,   0, 255};
+const SDL_Color DC_LINK_HOVER    = {  0,   0, 255, 255};
+const SDL_Color DC_TIMER_BG      = {  0, 125,   0, 255};
+const SDL_Color DC_TIMER_ELAPSED = {240, 204,  48, 255};
 // clang-format on
-
-StyleConfig_t get_style_config(const char *data_dir) {
-  StyleConfig_t cfg = {0};
-
-  char *cfg_path = canfigger_path_join(data_dir, "layout.conf");
-  if (!cfg_path)
-    return cfg;
-
-  struct Canfigger *node = canfigger_parse_file(cfg_path, ',');
-  free(cfg_path);
-  if (!node)
-    return cfg;
-
-  while (node) {
-    const char *k = node->key;
-    const char *v = node->value;
-
-    for (size_t i = 0; i < ARRAY_SIZE(style_fields); i++) {
-      if (strcasecmp(k, style_fields[i].key) != 0)
-        continue;
-      char *base = (char *)&cfg + style_fields[i].offset;
-      if (style_fields[i].type == STYLE_FONT) {
-        if (v) *(int *)base = parse_font(v);
-      } else if (style_fields[i].type == STYLE_COLOR) {
-        if (v) *(SDL_Color *)base = parse_color(v);
-      } else {
-        struct { SDL_Color bg, fg; } *pair = (void *)base;
-        if (v) pair->bg = parse_color(v);
-        char *attr = NULL;
-        canfigger_free_current_attr_str_advance(node->attributes, &attr);
-        if (attr) pair->fg = parse_color(attr);
-      }
-      break;
-    }
-
-    canfigger_free_current_key_node_advance(&node);
-  }
-
-  return cfg;
-}

--- a/src/style.c
+++ b/src/style.c
@@ -1,0 +1,167 @@
+/*
+ style.c
+ https://github.com/Dealer-s-Choice/dealers_choice
+
+ MIT License
+
+ Copyright (c) 2026 Andy Alt
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+*/
+
+#include <canfigger.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "graphics.h"
+#include "style.h"
+#include "util.h"
+
+StyleConfig_t g_style_cfg;
+
+static const struct {
+  const char *name;
+  SDL_Color color;
+} color_lookup[] = {
+    {"white",       {255, 255, 255, 255}},
+    {"lightgray",   {200, 200, 200, 255}},
+    {"gray",        {128, 128, 128, 255}},
+    {"darkgray",    { 64,  64,  64, 255}},
+    {"black",       {  0,   0,   0, 255}},
+    {"red",         {255,   0,   0, 255}},
+    {"green",       {  0, 255,   0, 255}},
+    {"table_green", {  0, 125,   0, 255}},
+    {"blue",        {  0,   0, 255, 255}},
+    {"yellow",      {255, 255,   0, 255}},
+    {"cyan",        {  0, 255, 255, 255}},
+    {"magenta",     {255,   0, 255, 255}},
+    {"orange",      {255, 165,   0, 255}},
+    {"gold",        {240, 204,  48, 255}},
+    {"purple",      {128,   0, 128, 255}},
+    {"brown",       {165,  42,  42, 255}},
+    {"pink",        {255, 192, 203, 255}},
+    {"teal",        {  0, 128, 128, 255}},
+};
+
+static const struct {
+  const char *name;
+  int idx;
+} font_lookup[] = {
+    {"card",         FONT_CARD},
+    {"default",      FONT_DEFAULT},
+    {"default_bold", FONT_DEFAULT_BOLD},
+    {"bold",         FONT_BOLD},
+    {"link",         FONT_LINK},
+    {"status_msg",   FONT_STATUS_MSG},
+    {"title",        FONT_TITLE},
+    {"version",      FONT_VERSION},
+    {"wild_select",  FONT_WILD_SELECT},
+};
+
+static SDL_Color parse_color(const char *s) {
+  if (!s || !*s)
+    return (SDL_Color){0, 0, 0, 255};
+  if (s[0] == '#') {
+    unsigned r, g, b, a = 255;
+    if (sscanf(s + 1, "%02x%02x%02x%02x", &r, &g, &b, &a) >= 3)
+      return (SDL_Color){(Uint8)r, (Uint8)g, (Uint8)b, (Uint8)a};
+  }
+  for (size_t i = 0; i < ARRAY_SIZE(color_lookup); i++)
+    if (strcasecmp(s, color_lookup[i].name) == 0)
+      return color_lookup[i].color;
+  SDL_Log("style: unknown color '%s'", s);
+  return (SDL_Color){0, 0, 0, 255};
+}
+
+static int parse_font(const char *s) {
+  if (!s || !*s)
+    return FONT_BOLD;
+  for (size_t i = 0; i < ARRAY_SIZE(font_lookup); i++)
+    if (strcasecmp(s, font_lookup[i].name) == 0)
+      return font_lookup[i].idx;
+  SDL_Log("style: unknown font '%s'", s);
+  return FONT_BOLD;
+}
+
+typedef enum { STYLE_COLOR, STYLE_PAIR, STYLE_FONT } FieldType_t;
+
+// clang-format off
+static const struct {
+  const char  *key;
+  FieldType_t  type;
+  size_t       offset;
+} style_fields[] = {
+  {"button_primary",  STYLE_PAIR,  offsetof(StyleConfig_t, button_primary)},
+  {"button_danger",   STYLE_PAIR,  offsetof(StyleConfig_t, button_danger)},
+  {"button_warn",     STYLE_PAIR,  offsetof(StyleConfig_t, button_warn)},
+  {"button_cancel",   STYLE_PAIR,  offsetof(StyleConfig_t, button_cancel)},
+  {"indicator_wild",  STYLE_PAIR,  offsetof(StyleConfig_t, indicator_wild)},
+  {"indicator_game",  STYLE_PAIR,  offsetof(StyleConfig_t, indicator_game)},
+  {"text_on_dark",    STYLE_COLOR, offsetof(StyleConfig_t, text_on_dark)},
+  {"text_on_light",   STYLE_COLOR, offsetof(StyleConfig_t, text_on_light)},
+  {"text_muted",      STYLE_COLOR, offsetof(StyleConfig_t, text_muted)},
+  {"link_normal",     STYLE_COLOR, offsetof(StyleConfig_t, link_normal)},
+  {"link_hover",      STYLE_COLOR, offsetof(StyleConfig_t, link_hover)},
+  {"timer_bg",        STYLE_COLOR, offsetof(StyleConfig_t, timer_bg)},
+  {"timer_elapsed",   STYLE_COLOR, offsetof(StyleConfig_t, timer_elapsed)},
+  {"button_font",     STYLE_FONT,  offsetof(StyleConfig_t, button_font)},
+  {"link_font",       STYLE_FONT,  offsetof(StyleConfig_t, link_font)},
+};
+// clang-format on
+
+StyleConfig_t get_style_config(const char *data_dir) {
+  StyleConfig_t cfg = {0};
+
+  char *cfg_path = canfigger_path_join(data_dir, "layout.conf");
+  if (!cfg_path)
+    return cfg;
+
+  struct Canfigger *node = canfigger_parse_file(cfg_path, ',');
+  free(cfg_path);
+  if (!node)
+    return cfg;
+
+  while (node) {
+    const char *k = node->key;
+    const char *v = node->value;
+
+    for (size_t i = 0; i < ARRAY_SIZE(style_fields); i++) {
+      if (strcasecmp(k, style_fields[i].key) != 0)
+        continue;
+      char *base = (char *)&cfg + style_fields[i].offset;
+      if (style_fields[i].type == STYLE_FONT) {
+        if (v) *(int *)base = parse_font(v);
+      } else if (style_fields[i].type == STYLE_COLOR) {
+        if (v) *(SDL_Color *)base = parse_color(v);
+      } else {
+        struct { SDL_Color bg, fg; } *pair = (void *)base;
+        if (v) pair->bg = parse_color(v);
+        char *attr = NULL;
+        canfigger_free_current_attr_str_advance(node->attributes, &attr);
+        if (attr) pair->fg = parse_color(attr);
+      }
+      break;
+    }
+
+    canfigger_free_current_key_node_advance(&node);
+  }
+
+  return cfg;
+}

--- a/src/style.h
+++ b/src/style.h
@@ -32,24 +32,29 @@
 #include <SDL2/SDL.h>
 
 typedef struct {
-  struct { SDL_Color bg, fg; } button_primary;   /* main actions: black bg, yellow fg */
-  struct { SDL_Color bg, fg; } button_danger;    /* quit/X: white bg, red fg */
-  struct { SDL_Color bg, fg; } button_warn;      /* kick/ban/bet amounts: brown bg, white fg */
-  struct { SDL_Color bg, fg; } button_cancel;    /* cancel dialogs: white bg, gray fg */
-  SDL_Color text_on_dark;   /* text on dark/colored backgrounds */
-  SDL_Color text_on_light;  /* text on light backgrounds */
-  SDL_Color text_muted;     /* subdued labels */
-  SDL_Color link_normal;
-  SDL_Color link_hover;
-  struct { SDL_Color bg, fg; } indicator_wild;
-  struct { SDL_Color bg, fg; } indicator_game;
-  SDL_Color timer_bg;       /* inner circle fill */
-  SDL_Color timer_elapsed;  /* elapsed-time wedge */
-  int button_font;  /* FONT_* index */
-  int link_font;    /* FONT_* index */
-} StyleConfig_t;
+  SDL_Color bg;
+  SDL_Color fg;
+  int       font_idx;
+  int       w_pad;
+  int       h_pad;
+} ButtonRole_t;
 
-extern StyleConfig_t g_style_cfg;
-StyleConfig_t get_style_config(const char *data_dir);
+extern const ButtonRole_t ROLE_PRIMARY;
+extern const ButtonRole_t ROLE_DANGER;
+extern const ButtonRole_t ROLE_ALT;
+extern const ButtonRole_t ROLE_CANCEL;
+
+extern const SDL_Color DC_INDICATOR_WILD_BG;
+extern const SDL_Color DC_INDICATOR_WILD_FG;
+extern const SDL_Color DC_INDICATOR_GAME_BG;
+extern const SDL_Color DC_INDICATOR_GAME_FG;
+
+extern const SDL_Color DC_TEXT_ON_DARK;
+extern const SDL_Color DC_TEXT_ON_LIGHT;
+extern const SDL_Color DC_TEXT_MUTED;
+extern const SDL_Color DC_LINK_NORMAL;
+extern const SDL_Color DC_LINK_HOVER;
+extern const SDL_Color DC_TIMER_BG;
+extern const SDL_Color DC_TIMER_ELAPSED;
 
 #endif

--- a/src/style.h
+++ b/src/style.h
@@ -1,5 +1,5 @@
 /*
- globals.h
+ style.h
  https://github.com/Dealer-s-Choice/dealers_choice
 
  MIT License
@@ -26,19 +26,30 @@
 
 */
 
-#ifndef __GLOBALS_H
-#define __GLOBALS_H
+#ifndef __STYLE_H
+#define __STYLE_H
 
-#include <deckhandler.h>
+#include <SDL2/SDL.h>
 
-#include "config.h"
-#include "graphics.h"
-#include "layout.h"
-#include "style.h"
+typedef struct {
+  struct { SDL_Color bg, fg; } button_primary;   /* main actions: black bg, yellow fg */
+  struct { SDL_Color bg, fg; } button_danger;    /* quit/X: white bg, red fg */
+  struct { SDL_Color bg, fg; } button_warn;      /* kick/ban/bet amounts: brown bg, white fg */
+  struct { SDL_Color bg, fg; } button_cancel;    /* cancel dialogs: white bg, gray fg */
+  SDL_Color text_on_dark;   /* text on dark/colored backgrounds */
+  SDL_Color text_on_light;  /* text on light backgrounds */
+  SDL_Color text_muted;     /* subdued labels */
+  SDL_Color link_normal;
+  SDL_Color link_hover;
+  struct { SDL_Color bg, fg; } indicator_wild;
+  struct { SDL_Color bg, fg; } indicator_game;
+  SDL_Color timer_bg;       /* inner circle fill */
+  SDL_Color timer_elapsed;  /* elapsed-time wedge */
+  int button_font;  /* FONT_* index */
+  int link_font;    /* FONT_* index */
+} StyleConfig_t;
 
-extern pcg32_random_t rng;
-
-extern SDL_Rect g_viewport;
-extern SDL_Point g_center;
+extern StyleConfig_t g_style_cfg;
+StyleConfig_t get_style_config(const char *data_dir);
 
 #endif

--- a/src/util.h
+++ b/src/util.h
@@ -33,6 +33,10 @@ extern bool verbose;
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
+#ifdef _MSC_VER
+#define strcasecmp _stricmp
+#endif
+
 typedef struct {
   char data[2048];
   char config[2048];

--- a/src/widgets/button.c
+++ b/src/widgets/button.c
@@ -75,18 +75,18 @@ static void button_widget_destroy(UIWidget_t *w) {
   free(bw);
 }
 
-ButtonWidget_t *button_widget_create(const char *text, EColor_t color, TTF_Font *font,
-                                     SDL_Keycode hotkey) {
+static ButtonWidget_t *button_init(const char *text, SDL_Color bg, SDL_Color fg,
+                                   TTF_Font *font, SDL_Keycode hotkey) {
   ButtonWidget_t *bw = calloc(1, sizeof(*bw));
   if (!bw)
     return NULL;
 
-  bw->color = (Color_t){get_color(color.bg), get_color(color.fg)};
+  bw->color = (Color_t){bg, fg};
   bw->hotkey = hotkey;
   bw->click.duration = 80;
   bw->interactive = true;
 
-  bw->text = text_widget_create(text, font, get_color(color.fg));
+  bw->text = text_widget_create(text, font, fg);
   if (!bw->text) {
     free(bw);
     return NULL;
@@ -110,4 +110,14 @@ ButtonWidget_t *button_widget_create(const char *text, EColor_t color, TTF_Font 
   bw->base.destroy = button_widget_destroy;
 
   return bw;
+}
+
+ButtonWidget_t *button_widget_create(const char *text, EColor_t color, TTF_Font *font,
+                                     SDL_Keycode hotkey) {
+  return button_init(text, get_color(color.bg), get_color(color.fg), font, hotkey);
+}
+
+ButtonWidget_t *button_widget_create_colored(const char *text, SDL_Color bg, SDL_Color fg,
+                                             TTF_Font *font, SDL_Keycode hotkey) {
+  return button_init(text, bg, fg, font, hotkey);
 }

--- a/src/widgets/button.c
+++ b/src/widgets/button.c
@@ -76,7 +76,7 @@ static void button_widget_destroy(UIWidget_t *w) {
 }
 
 static ButtonWidget_t *button_init(const char *text, SDL_Color bg, SDL_Color fg,
-                                   TTF_Font *font, SDL_Keycode hotkey) {
+                                   TTF_Font *font, SDL_Keycode hotkey, int w_pad, int h_pad) {
   ButtonWidget_t *bw = calloc(1, sizeof(*bw));
   if (!bw)
     return NULL;
@@ -104,20 +104,16 @@ static ButtonWidget_t *button_init(const char *text, SDL_Color bg, SDL_Color fg,
     th = 20;
   }
 
-  bw->base.rect.w = tw + g_layout_cfg.button_w_pad;
-  bw->base.rect.h = th + g_layout_cfg.button_h_pad;
+  bw->base.rect.w = tw + w_pad;
+  bw->base.rect.h = th + h_pad;
   bw->base.render = button_widget_render;
   bw->base.destroy = button_widget_destroy;
 
   return bw;
 }
 
-ButtonWidget_t *button_widget_create(const char *text, EColor_t color, TTF_Font *font,
-                                     SDL_Keycode hotkey) {
-  return button_init(text, get_color(color.bg), get_color(color.fg), font, hotkey);
-}
-
-ButtonWidget_t *button_widget_create_colored(const char *text, SDL_Color bg, SDL_Color fg,
-                                             TTF_Font *font, SDL_Keycode hotkey) {
-  return button_init(text, bg, fg, font, hotkey);
+ButtonWidget_t *button_widget_create_styled(const char *text, const ButtonRole_t *role,
+                                            TTF_Font * const *fonts, SDL_Keycode hotkey) {
+  return button_init(text, role->bg, role->fg, fonts[role->font_idx], hotkey,
+                     role->w_pad, role->h_pad);
 }

--- a/src/widgets/button.h
+++ b/src/widgets/button.h
@@ -39,5 +39,7 @@ typedef struct {
 
 ButtonWidget_t *button_widget_create(const char *text, EColor_t color, TTF_Font *font,
                                      SDL_Keycode hotkey);
+ButtonWidget_t *button_widget_create_colored(const char *text, SDL_Color bg, SDL_Color fg,
+                                             TTF_Font *font, SDL_Keycode hotkey);
 
 #endif

--- a/src/widgets/button.h
+++ b/src/widgets/button.h
@@ -4,6 +4,7 @@
 #include <SDL2/SDL.h>
 
 #include "graphics.h"
+#include "style.h"
 #include "text.h"
 
 #define CLICKED_DEFAULT                                                                            \
@@ -23,11 +24,6 @@ typedef struct {
 } Color_t;
 
 typedef struct {
-  EColorName_t bg;
-  EColorName_t fg;
-} EColor_t;
-
-typedef struct {
   UIWidget_t base;
   TextWidget_t *text;
   TextWidget_t *text_disabled;
@@ -37,9 +33,7 @@ typedef struct {
   bool interactive;
 } ButtonWidget_t;
 
-ButtonWidget_t *button_widget_create(const char *text, EColor_t color, TTF_Font *font,
-                                     SDL_Keycode hotkey);
-ButtonWidget_t *button_widget_create_colored(const char *text, SDL_Color bg, SDL_Color fg,
-                                             TTF_Font *font, SDL_Keycode hotkey);
+ButtonWidget_t *button_widget_create_styled(const char *text, const ButtonRole_t *role,
+                                            TTF_Font * const *fonts, SDL_Keycode hotkey);
 
 #endif

--- a/src/widgets/indicator.c
+++ b/src/widgets/indicator.c
@@ -100,8 +100,8 @@ void indicator_render(UIWidget_t *w) {
   ui_widget_render(&ind->text->base);
 }
 
-Indicator_t *create_indicator(const char *text, TTF_Font *font, EColorName_t bg_color,
-                              EColorName_t fg_color) {
+static Indicator_t *indicator_init(const char *text, TTF_Font *font,
+                                   SDL_Color bg_color, SDL_Color fg_color) {
   SDL_Renderer *renderer = g_sdl_context->renderer;
   if (!renderer || !text || !font)
     return NULL;
@@ -111,29 +111,36 @@ Indicator_t *create_indicator(const char *text, TTF_Font *font, EColorName_t bg_
     return NULL;
 
   ind->renderer = renderer;
-  ind->bg_color = get_color(bg_color);
+  ind->bg_color = bg_color;
 
-  ind->text = text_widget_create(text, font, get_color(fg_color));
+  ind->text = text_widget_create(text, font, fg_color);
   if (!ind->text) {
     free(ind);
     return NULL;
   }
 
-  // Compute indicator rectangle with padding
   int text_w = ind->text->base.rect.w;
   int text_h = ind->text->base.rect.h;
-  int pad_x = text_h;     // horizontal padding
-  int pad_y = text_h / 3; // vertical padding
+  int pad_x = text_h;
+  int pad_y = text_h / 3;
   ind->base.rect.w = text_w + pad_x * 2;
   ind->base.rect.h = text_h + pad_y * 2;
 
-  // Precompute oval radii
   ind->rx = ind->base.rect.w / 2;
   ind->ry = ind->base.rect.h / 2;
 
-  // Assign callbacks
   ind->base.render = indicator_render;
   ind->base.destroy = text_wrapper_destroy;
 
   return ind;
+}
+
+Indicator_t *create_indicator(const char *text, TTF_Font *font, EColorName_t bg_color,
+                              EColorName_t fg_color) {
+  return indicator_init(text, font, get_color(bg_color), get_color(fg_color));
+}
+
+Indicator_t *create_indicator_colored(const char *text, TTF_Font *font,
+                                      SDL_Color bg_color, SDL_Color fg_color) {
+  return indicator_init(text, font, bg_color, fg_color);
 }

--- a/src/widgets/indicator.h
+++ b/src/widgets/indicator.h
@@ -60,5 +60,7 @@ the pre-created texture.
 
 Indicator_t *create_indicator(const char *text, TTF_Font *font, EColorName_t bg_color,
                               EColorName_t fg_color);
+Indicator_t *create_indicator_colored(const char *text, TTF_Font *font,
+                                      SDL_Color bg_color, SDL_Color fg_color);
 
 #endif

--- a/src/widgets/link.c
+++ b/src/widgets/link.c
@@ -40,13 +40,13 @@ LinkWidget_t *link_widget_create(const char *text, const char *url, TTF_Font *fo
   lw->url = url;
 
   TTF_SetFontStyle(font, TTF_STYLE_UNDERLINE);
-  lw->text_normal = text_widget_create(text, font, get_color(COLOR_BLACK));
+  lw->text_normal = text_widget_create(text, font, g_style_cfg.link_normal);
   if (!lw->text_normal) {
     TTF_SetFontStyle(font, TTF_STYLE_NORMAL);
     free(lw);
     return NULL;
   }
-  lw->text_hovered = text_widget_create(text, font, get_color(COLOR_BLUE));
+  lw->text_hovered = text_widget_create(text, font, g_style_cfg.link_hover);
   TTF_SetFontStyle(font, TTF_STYLE_NORMAL);
   if (!lw->text_hovered) {
     ui_widget_destroy(&lw->text_normal->base);

--- a/src/widgets/link.c
+++ b/src/widgets/link.c
@@ -40,13 +40,13 @@ LinkWidget_t *link_widget_create(const char *text, const char *url, TTF_Font *fo
   lw->url = url;
 
   TTF_SetFontStyle(font, TTF_STYLE_UNDERLINE);
-  lw->text_normal = text_widget_create(text, font, g_style_cfg.link_normal);
+  lw->text_normal = text_widget_create(text, font, DC_LINK_NORMAL);
   if (!lw->text_normal) {
     TTF_SetFontStyle(font, TTF_STYLE_NORMAL);
     free(lw);
     return NULL;
   }
-  lw->text_hovered = text_widget_create(text, font, g_style_cfg.link_hover);
+  lw->text_hovered = text_widget_create(text, font, DC_LINK_HOVER);
   TTF_SetFontStyle(font, TTF_STYLE_NORMAL);
   if (!lw->text_hovered) {
     ui_widget_destroy(&lw->text_normal->base);

--- a/src/widgets/ping.c
+++ b/src/widgets/ping.c
@@ -22,7 +22,7 @@ PingWidget_t *ping_widget_create(int ping, TTF_Font *font) {
   char buf[32];
   snprintf(buf, sizeof buf, "%dms", ping);
 
-  pw->text = text_widget_create(buf, font, g_style_cfg.text_on_dark);
+  pw->text = text_widget_create(buf, font, DC_TEXT_ON_DARK);
   pw->ping = ping;
 
   // IMPORTANT: propagate size to base widget

--- a/src/widgets/ping.c
+++ b/src/widgets/ping.c
@@ -1,4 +1,5 @@
 #include "ping.h"
+#include "style.h"
 
 static void ping_widget_render(UIWidget_t *w) {
   PingWidget_t *pw = (PingWidget_t *)w;
@@ -21,7 +22,7 @@ PingWidget_t *ping_widget_create(int ping, TTF_Font *font) {
   char buf[32];
   snprintf(buf, sizeof buf, "%dms", ping);
 
-  pw->text = text_widget_create(buf, font, get_color(COLOR_WHITE));
+  pw->text = text_widget_create(buf, font, g_style_cfg.text_on_dark);
   pw->ping = ping;
 
   // IMPORTANT: propagate size to base widget


### PR DESCRIPTION
Widget colors and font choices are now read from layout.conf at startup rather than hardcoded at call sites. A [styles] section maps semantic roles (button_primary, text_on_dark, indicator_wild, timer_elapsed, etc.) to named or hex colors and FONT_* font indices.

Key design points:
- StyleConfig_t and g_style_cfg live in style.h/style.c (not layout.h)
- Parsing uses a static offset table (key + FieldType_t + offsetof + defaults) — no else-if chain; adding a field is one table row
- Color-pair roles (bg + fg) use canfigger's comma-attribute syntax
- button_widget_create_colored() and create_indicator_colored() added as SDL_Color entry points alongside the existing EColor_t versions
- style.h is included via globals.h; files outside that chain include it directly