### PR TITLE
tests: pin per-IP connection rate-limit sliding-window behavior

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -50,8 +50,11 @@ typedef struct {
 static ConnAttempt_t conn_attempts[RATE_LIMIT_CAPACITY];
 static int conn_attempts_count = 0;
 
-static bool rate_limit_check(const char *ip_str, uint32_t max_per_minute) {
-  uint32_t now = SDL_GetTicks();
+/* Same logic as rate_limit_check() below but with `now_ms` injected so the
+ * unit test (tests/rate_limit.c) can advance time without sleeping.  Production
+ * code calls rate_limit_check() which passes SDL_GetTicks(). */
+bool dc_rate_limit_check_at(const char *ip_str, uint32_t max_per_minute, uint32_t now_ms) {
+  uint32_t now = now_ms;
   int j = 0;
   for (int i = 0; i < conn_attempts_count; i++) {
     if (now - conn_attempts[i].ticks < RATE_LIMIT_WINDOW_MS)
@@ -76,6 +79,16 @@ static bool rate_limit_check(const char *ip_str, uint32_t max_per_minute) {
   }
 
   return true;
+}
+
+/* Clear the in-process rate-limit state.  For tests only; production never
+ * needs this because each server invocation starts with empty state. */
+void dc_rate_limit_reset(void) {
+  conn_attempts_count = 0;
+}
+
+static bool rate_limit_check(const char *ip_str, uint32_t max_per_minute) {
+  return dc_rate_limit_check_at(ip_str, max_per_minute, SDL_GetTicks());
 }
 #define MAX_WILDS 4
 

--- a/src/server.h
+++ b/src/server.h
@@ -53,4 +53,11 @@ void game_seven_card_no_peek(GAME_ARGS);
 
 int run_server(const CliArgs_t *cli_args, Path_t *path);
 
+/* Connection rate-limit helpers, exposed for tests.  Production code uses
+ * the internal rate_limit_check() wrapper which feeds SDL_GetTicks() into
+ * dc_rate_limit_check_at(); the test (tests/rate_limit.c) injects its own
+ * clock to exercise window expiry without sleeping. */
+bool dc_rate_limit_check_at(const char *ip_str, uint32_t max_per_minute, uint32_t now_ms);
+void dc_rate_limit_reset(void);
+
 #endif

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -5,6 +5,7 @@ unit_tests = [
   'debug_print_cards',
   'layout_cards',
   'no_peek',
+  'rate_limit',
 ]
 
 base_env = {

--- a/tests/rate_limit.c
+++ b/tests/rate_limit.c
@@ -1,0 +1,94 @@
+/* Pins down the sliding-window behavior of the per-IP connection rate
+ * limiter (rate_limit_check in src/server.c).  Time is injected via
+ * dc_rate_limit_check_at() so the test can verify window expiry without
+ * sleeping. */
+
+#include "00_test.h"
+
+#define WINDOW_MS 60000u
+
+static void test_burst_then_reject(void) {
+  dc_rate_limit_reset();
+
+  /* Five rapid attempts at t=0 with max=5: all admitted. */
+  for (uint32_t i = 0; i < 5; i++)
+    assert(dc_rate_limit_check_at("1.2.3.4", 5, 0));
+
+  /* Sixth attempt within the window: rejected. */
+  assert(!dc_rate_limit_check_at("1.2.3.4", 5, 1));
+
+  /* Repeated attempts inside the window stay rejected — the rejected
+   * attempt itself doesn't extend the window (no new entry recorded). */
+  for (uint32_t t = 100; t < WINDOW_MS; t += 1000)
+    assert(!dc_rate_limit_check_at("1.2.3.4", 5, t));
+}
+
+static void test_per_ip_counters_are_independent(void) {
+  dc_rate_limit_reset();
+
+  /* IP A hits its limit. */
+  for (uint32_t i = 0; i < 3; i++)
+    assert(dc_rate_limit_check_at("10.0.0.1", 3, i));
+  assert(!dc_rate_limit_check_at("10.0.0.1", 3, 4));
+
+  /* IP B is unaffected. */
+  for (uint32_t i = 0; i < 3; i++)
+    assert(dc_rate_limit_check_at("10.0.0.2", 3, 4 + i));
+  assert(!dc_rate_limit_check_at("10.0.0.2", 3, 100));
+
+  /* IP A still capped. */
+  assert(!dc_rate_limit_check_at("10.0.0.1", 3, 200));
+}
+
+static void test_sliding_window_recovery(void) {
+  dc_rate_limit_reset();
+
+  /* Three attempts at t=0,1,2 with max=3 → all allowed. */
+  for (uint32_t i = 0; i < 3; i++)
+    assert(dc_rate_limit_check_at("172.16.0.1", 3, i));
+
+  /* At t=3 we're at the cap → rejected. */
+  assert(!dc_rate_limit_check_at("172.16.0.1", 3, 3));
+
+  /* Still rejected just before the window slides off the oldest entry
+   * (now - ticks(0) = 59999 < WINDOW_MS). */
+  assert(!dc_rate_limit_check_at("172.16.0.1", 3, WINDOW_MS - 1));
+
+  /* At t=WINDOW_MS, the t=0 entry is exactly at the boundary
+   * (now - ticks == WINDOW_MS, not strictly <) and gets pruned.  Count
+   * drops to 2 → allowed.  This is the user-visible "I got rejected,
+   * then I could connect again" moment. */
+  assert(dc_rate_limit_check_at("172.16.0.1", 3, WINDOW_MS));
+
+  /* And — perhaps counterintuitively — the t=1 entry also slides off at
+   * t=WINDOW_MS+1, so a second attempt right after also gets in.  This
+   * is how the sliding window behaves when the original entries were
+   * close together: they expire close together, giving another short
+   * burst before the cap is hit again.  This is the exact behavior the
+   * user described as "until the limit was hit again". */
+  assert(dc_rate_limit_check_at("172.16.0.1", 3, WINDOW_MS + 1));
+  assert(dc_rate_limit_check_at("172.16.0.1", 3, WINDOW_MS + 2));
+
+  /* Now the three new entries are at t = WINDOW_MS, WINDOW_MS+1,
+   * WINDOW_MS+2 — none yet expired — so we're back at the cap. */
+  assert(!dc_rate_limit_check_at("172.16.0.1", 3, WINDOW_MS + 3));
+}
+
+static void test_higher_max_admits_more(void) {
+  dc_rate_limit_reset();
+
+  /* 10-per-minute permits a 10-burst; 11th is rejected. */
+  for (uint32_t i = 0; i < 10; i++)
+    assert(dc_rate_limit_check_at("192.168.1.1", 10, i));
+  assert(!dc_rate_limit_check_at("192.168.1.1", 10, 11));
+}
+
+_MAIN_HEAD_
+(void)argc;
+(void)argv;
+test_burst_then_reject();
+test_per_ip_counters_are_independent();
+test_sliding_window_recovery();
+test_higher_max_admits_more();
+fprintf(stderr, "rate-limit tests: OK\n");
+_MAIN_TAIL_


### PR DESCRIPTION
New tests/rate_limit.c exercises rate_limit_check (the per-IP connection limiter in src/server.c) via an injected clock so the sliding-window semantics are pinned down without sleeping.  Notable case: when the initial N attempts cluster close together their entries also expire close together, so once the cap is hit you get roughly N more allowed attempts at 'now == WINDOW_MS + delta' before hitting the cap again — working as designed but visible as 'rejected, then I could connect again until the limit was hit again' under burst-style testing.

Minor server.c refactor: expose dc_rate_limit_check_at (the now-injectable form) and dc_rate_limit_reset so the test can drive the limiter deterministically.  Production rate_limit_check is now a thin wrapper around dc_rate_limit_check_at(SDL_GetTicks()).