### PR TITLE
bot: deal even when no new server message arrives in the menu lull

### DIFF
--- a/src/bot.c
+++ b/src/bot.c
@@ -490,9 +490,18 @@ int main(int argc, char *argv[]) {
       action_after = SDL_GetTicks() + delay_ms;
     }
 
-    /* Nothing received and no action timer has fired: nothing to do */
+    /* Nothing received and no action timer has fired: nothing to do —
+     * UNLESS we have a pending dealer game-select that's now due to
+     * fire.  Without this exception, the bot would set
+     * game_select_after on the broadcast it sees when the second
+     * player joins, then `continue` past the deal trigger on every
+     * subsequent iteration (recv returns RECV_NOTHING in the menu
+     * lull), and the server's dealer_timeout would expire instead. */
+    bool game_select_due =
+        game_state.at_menu && game_state.dealer_id == my_id && !game_select_sent &&
+        game_select_after != 0 && SDL_GetTicks() >= game_select_after;
     if (status == RECV_NOTHING) {
-      if (!any_action || SDL_GetTicks() < action_after)
+      if ((!any_action || SDL_GetTicks() < action_after) && !game_select_due)
         continue;
     }
 


### PR DESCRIPTION
When the bot starts before any other player joins, then a second player connects, the bot reads the broadcast (RECV_SUCCESS), sees n_connected >= 2, and sets game_select_after = now + 4-10s.  Every subsequent iteration recv returns RECV_NOTHING (no traffic during the menu lull beyond the 5-second pings), and the bot hits

    if (status == RECV_NOTHING) {
      if (!any_action || SDL_GetTicks() < action_after)
        continue;
    }

which short-circuits past the game-select check at line ~523.  So the deal timer expires but the bot never re-evaluates whether to fire it. The server's 30s dealer_timeout then expires and seat rotates to the joining player — which is why the user sees "the bot times out and makes me deal the first hand" and only subsequent hands deal cleanly (by then ping/state traffic is regular enough that RECV_SUCCESS keeps firing).

Fix: compute game_select_due in advance and let the iteration fall through when a deal is pending and the timer has elapsed.