### PR TITLE
widgets: pre-render all card text textures at GUI startup (atlas)

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -46,6 +46,7 @@
 #include "globals.h"
 #include "graphics.h"
 #include "widgets/button.h"
+#include "widgets/card_text_atlas.h"
 #include "widgets/dealer.h"
 #include "widgets/image.h"
 #include "widgets/indicator.h"
@@ -580,9 +581,11 @@ cleanup:
 static void make_human_readable_card(DH_Card *card, CardWidget_t *cw) {
   const char *face = DH_get_card_face_str(card->face_val);
   const char *suit = DH_get_card_unicode_suit(*card);
-  cw->textColor = (card->suit == DH_SUIT_HEARTS || card->suit == DH_SUIT_DIAMONDS)
-                      ? get_color(COLOR_RED)
-                      : get_color(COLOR_BLACK);
+  /* face_val + suit drive the card_text_atlas lookup in
+   * card_widget_render — the actual TTF render happens once at
+   * GUI startup, not per-frame. */
+  cw->face_val = card->face_val;
+  cw->suit = card->suit;
   snprintf(cw->text, sizeof(cw->text), "%s%s", face, suit);
   if (strlen(cw->text) == 0) {
     fprintf(stderr, "%s:String length 0\n", __func__);
@@ -2478,6 +2481,9 @@ cleanup:
 }
 
 void do_sdl_cleanup(SdlContext_t *sdl_context) {
+  /* Atlas textures are tied to sdl_context->renderer — must be freed
+   * before the renderer they were created with. */
+  card_text_atlas_destroy();
   SDL_DestroyRenderer(sdl_context->renderer);
   SDL_DestroyWindow(sdl_context->window);
   SDL_Quit();

--- a/src/main.c
+++ b/src/main.c
@@ -44,6 +44,7 @@
 #include "server.h"
 #include "util.h"
 #include "widgets/button.h"
+#include "widgets/card_text_atlas.h"
 #include "widgets/checkbox.h"
 #include "widgets/image.h"
 #include "widgets/input.h"
@@ -888,6 +889,13 @@ int main(int argc, char *argv[]) {
     fprintf(stderr, "Unable to load config\n");
     exit(EXIT_FAILURE);
   }
+
+  /* Pre-render all 52 card text textures once.  card_widget_render
+   * looks them up by (face_val, suit); otherwise it would call
+   * TTF_RenderUTF8_Blended + SDL_CreateTextureFromSurface every frame
+   * for every card (~6M allocations per 4 min of gameplay before this
+   * cache landed). */
+  card_text_atlas_init(sdl_context.renderer, font.fonts[FONT_CARD]);
 
 #ifdef ENABLE_NLS
   if (strlen(player_config.language) != 0) {

--- a/src/widgets/card.c
+++ b/src/widgets/card.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 
 #include "card.h"
+#include "card_text_atlas.h"
 #include "globals.h"
 #include "graphics.h"
 #include "util.h"
@@ -531,31 +532,30 @@ static void card_widget_render(UIWidget_t *w) {
   SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
   SDL_RenderDrawRect(renderer, &w->rect);
 
-  SDL_Surface *textSurface = TTF_RenderUTF8_Blended(cw->font, cw->text, cw->textColor);
-  if (!textSurface) {
-    fprintf(stderr, "TTF_RenderUTF8_Blended failed: %s\n", TTF_GetError());
-    exit(EXIT_FAILURE);
+  /* Look up the pre-rendered text texture from the atlas built at GUI
+   * startup.  Replaces the per-frame TTF_RenderUTF8_Blended +
+   * SDL_CreateTextureFromSurface that used to be here — that path was
+   * the #1 allocator in heaptrack profiles, ~6M calls / 4 min of
+   * gameplay. */
+  int text_w = 0, text_h = 0;
+  SDL_Texture *text_texture = card_text_atlas_get(cw->face_val, cw->suit, &text_w, &text_h);
+  if (!text_texture) {
+    /* Either the atlas wasn't initialised or the face/suit pair is
+     * out of range.  Either way an empty card face is the safe
+     * fallback; the card border is already drawn. */
+    return;
   }
-
-  SDL_Texture *textTexture = SDL_CreateTextureFromSurface(renderer, textSurface);
-  if (!textTexture) {
-    fprintf(stderr, "SDL_CreateTextureFromSurface failed: %s\n", SDL_GetError());
-    SDL_FreeSurface(textSurface);
-    exit(EXIT_FAILURE);
-  }
-
-  SDL_Rect textRect = {w->rect.x + (g_layout_cfg.card_w - textSurface->w) / 2,
-                       w->rect.y + (g_layout_cfg.card_h - textSurface->h) / 2, textSurface->w, textSurface->h};
-
-  SDL_RenderCopy(renderer, textTexture, NULL, &textRect);
-  SDL_FreeSurface(textSurface);
-  SDL_DestroyTexture(textTexture);
+  SDL_Rect textRect = {w->rect.x + (g_layout_cfg.card_w - text_w) / 2,
+                       w->rect.y + (g_layout_cfg.card_h - text_h) / 2, text_w, text_h};
+  SDL_RenderCopy(renderer, text_texture, NULL, &textRect);
 }
 
 static void card_widget_destroy(UIWidget_t *w) { free(w); }
 
 void card_widget_init(CardWidget_t *cw, TTF_Font *font) {
   cw->font = font;
+  cw->face_val = 0;
+  cw->suit = 0;
   cw->base.rect.w = g_layout_cfg.card_w;
   cw->base.rect.h = g_layout_cfg.card_h;
   cw->base.render = card_widget_render;

--- a/src/widgets/card.h
+++ b/src/widgets/card.h
@@ -36,14 +36,22 @@
 
 typedef struct {
   UIWidget_t base; /* base.hovered and base.selected are used for interaction */
+  /* text[] is kept for debug / external observers; rendering goes through
+   * card_text_atlas_get(face_val, suit) so the string itself is no longer
+   * on the render hot path. */
   char text[SIZEOF_CARD_TEXT];
-  SDL_Color textColor;
+  /* Card identity used by the atlas lookup in card_widget_render.
+   * Set by make_human_readable_card() when the card slot is populated;
+   * unused when is_back or is_null. */
+  int face_val;
+  int suit;
   bool is_back;
   bool is_null;
   bool is_wild;
   bool is_winning;
   bool my_card; /* true when this card belongs to the local player */
-  TTF_Font *font;
+  TTF_Font *font; /* kept for the card-back animated patterns that still
+                   * compute glyph metrics; not used for face rendering. */
 } CardWidget_t;
 
 void card_widget_init(CardWidget_t *cw, TTF_Font *font);

--- a/src/widgets/card_text_atlas.c
+++ b/src/widgets/card_text_atlas.c
@@ -1,0 +1,140 @@
+/*
+ widgets/card_text_atlas.c
+ https://github.com/Dealer-s-Choice/dealers_choice
+
+ MIT License
+
+ Copyright (c) 2026 Andy Alt
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+*/
+
+#include "card_text_atlas.h"
+
+#include "deckhandler.h"
+#include "style.h"
+
+#include <stdio.h>
+
+/* Atlas storage: indexed by [face_val][suit].  face_val runs 1..13
+ * (DH_CARD_ACE..DH_CARD_KING) so we waste slot [0]; that's 13 * 4 *
+ * sizeof(SDL_Texture*) = 416 bytes of wasted CPU pointers, negligible
+ * vs the alternative of subtracting 1 every lookup and making the
+ * code harder to read. */
+#define ATLAS_FACES 15 /* 0..14 inclusive, indices 1..13 used */
+#define ATLAS_SUITS 4
+
+static struct {
+  SDL_Texture *texture;
+  int w, h;
+} g_atlas[ATLAS_FACES][ATLAS_SUITS];
+
+static bool g_initialised = false;
+static SDL_Renderer *g_renderer = NULL;
+static TTF_Font *g_font = NULL;
+
+static void destroy_locked(void) {
+  for (int f = 0; f < ATLAS_FACES; f++)
+    for (int s = 0; s < ATLAS_SUITS; s++) {
+      if (g_atlas[f][s].texture) {
+        SDL_DestroyTexture(g_atlas[f][s].texture);
+        g_atlas[f][s].texture = NULL;
+      }
+      g_atlas[f][s].w = g_atlas[f][s].h = 0;
+    }
+}
+
+void card_text_atlas_init(SDL_Renderer *renderer, TTF_Font *font) {
+  /* If already initialised for the same font, no-op so callers can
+   * be defensive without burning cycles. */
+  if (g_initialised && g_renderer == renderer && g_font == font)
+    return;
+  destroy_locked();
+  g_renderer = renderer;
+  g_font = font;
+  g_initialised = false;
+
+  for (int face = DH_CARD_ACE; face <= DH_CARD_KING; face++) {
+    const char *face_str = DH_get_card_face_str(face);
+    if (!face_str)
+      continue;
+    for (int suit = 0; suit < ATLAS_SUITS; suit++) {
+      DH_Card card = {.face_val = face, .suit = suit};
+      const char *suit_str = DH_get_card_unicode_suit(card);
+      if (!suit_str)
+        continue;
+      char text[24];
+      snprintf(text, sizeof(text), "%s%s", face_str, suit_str);
+
+      /* Same color convention as make_human_readable_card in
+       * src/client.c: red for hearts and diamonds, black for spades
+       * and clubs.  Kept inline rather than via get_color() to avoid
+       * an interface cycle with the styles config. */
+      SDL_Color color = (suit == DH_SUIT_HEARTS || suit == DH_SUIT_DIAMONDS)
+                            ? (SDL_Color){200, 0, 0, 255}
+                            : (SDL_Color){0, 0, 0, 255};
+
+      SDL_Surface *surface = TTF_RenderUTF8_Blended(font, text, color);
+      if (!surface) {
+        fprintf(stderr, "card_text_atlas_init: TTF_RenderUTF8_Blended(%s) failed: %s\n",
+                text, TTF_GetError());
+        continue;
+      }
+      SDL_Texture *texture = SDL_CreateTextureFromSurface(renderer, surface);
+      if (!texture) {
+        fprintf(stderr, "card_text_atlas_init: SDL_CreateTextureFromSurface(%s) failed: %s\n",
+                text, SDL_GetError());
+        SDL_FreeSurface(surface);
+        continue;
+      }
+      g_atlas[face][suit].texture = texture;
+      g_atlas[face][suit].w = surface->w;
+      g_atlas[face][suit].h = surface->h;
+      SDL_FreeSurface(surface);
+    }
+  }
+  g_initialised = true;
+}
+
+void card_text_atlas_destroy(void) {
+  destroy_locked();
+  g_renderer = NULL;
+  g_font = NULL;
+  g_initialised = false;
+}
+
+SDL_Texture *card_text_atlas_get(int face_val, int suit_val, int *out_w, int *out_h) {
+  if (!g_initialised)
+    return NULL;
+  if (face_val < DH_CARD_ACE || face_val > DH_CARD_KING)
+    return NULL;
+  if (suit_val < 0 || suit_val >= ATLAS_SUITS)
+    return NULL;
+  SDL_Texture *t = g_atlas[face_val][suit_val].texture;
+  if (!t)
+    return NULL;
+  if (out_w)
+    *out_w = g_atlas[face_val][suit_val].w;
+  if (out_h)
+    *out_h = g_atlas[face_val][suit_val].h;
+  return t;
+}
+
+bool card_text_atlas_is_initialised(void) { return g_initialised; }

--- a/src/widgets/card_text_atlas.h
+++ b/src/widgets/card_text_atlas.h
@@ -1,0 +1,84 @@
+/*
+ widgets/card_text_atlas.h
+ https://github.com/Dealer-s-Choice/dealers_choice
+
+ MIT License
+
+ Copyright (c) 2026 Andy Alt
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+*/
+
+#ifndef __CARD_TEXT_ATLAS_H
+#define __CARD_TEXT_ATLAS_H
+
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_ttf.h>
+#include <stdbool.h>
+
+/* Builds a per-(face, suit) text texture for every card in the deck and
+ * caches them for the lifetime of the GUI session.  Replaces the
+ * per-frame TTF_RenderUTF8_Blended + SDL_CreateTextureFromSurface
+ * pair that card_widget_render used to do — now that path is a single
+ * lookup + SDL_RenderCopy per card per frame, zero allocations.
+ *
+ * Must be called after SDL + TTF are initialised and after the
+ * renderer + font are created.  Safe to call multiple times
+ * (subsequent calls reuse the existing atlas if the font hasn't
+ * changed; pass a different font to rebuild).
+ *
+ * `font` is the TTF_Font used for card faces — typically
+ * font->fonts[FONT_CARD] in the client.  The atlas does NOT take
+ * ownership of the font or renderer; callers retain responsibility
+ * for those.
+ */
+void card_text_atlas_init(SDL_Renderer *renderer, TTF_Font *font);
+
+/* Frees every cached texture and resets the atlas.  Call before
+ * destroying the SDL_Renderer the atlas was initialised with —
+ * SDL_DestroyTexture on a texture whose renderer is already gone is
+ * undefined behavior. */
+void card_text_atlas_destroy(void);
+
+/* Returns the cached texture for the given face/suit pair, plus its
+ * pixel dimensions.  Returns NULL (with *out_w / *out_h untouched)
+ * when:
+ *   - the atlas hasn't been initialised yet,
+ *   - the (face_val, suit) is outside the dealt range
+ *     (face_val 1..13, suit 0..3),
+ *   - or the initial render for this card failed and the slot is
+ *     empty.  Callers should fall back to a draw-time render in that
+ *     case (or, more typically, treat it as a fatal init bug).
+ *
+ * The returned texture is owned by the atlas — do not call
+ * SDL_DestroyTexture on it. */
+SDL_Texture *card_text_atlas_get(int face_val, int suit_val, int *out_w, int *out_h);
+
+/* True once card_text_atlas_init has succeeded.  Tests and asserts
+ * use this to confirm the lifecycle without leaking the internal
+ * static arrays. */
+bool card_text_atlas_is_initialised(void);
+
+/* Total number of textures the atlas holds when fully populated.
+ * 13 faces × 4 suits = 52.  Exposed for tests so they don't have to
+ * encode the constant separately. */
+#define CARD_TEXT_ATLAS_SIZE 52
+
+#endif

--- a/src/widgets/meson.build
+++ b/src/widgets/meson.build
@@ -1,6 +1,7 @@
 widgets_src = files(
   'button.c',
   'card.c',
+  'card_text_atlas.c',
   'checkbox.c',
   'dealer.c',
   'image.c',

--- a/tests/README.md
+++ b/tests/README.md
@@ -142,7 +142,53 @@ making the link so chaotic that real bugs hide under transport noise.
 
     sudo tc qdisc del dev lo root
 
-### What it stresses
+## Profiling memory allocations with heaptrack
+
+When investigating allocation hot paths in the GUI client (e.g. the
+per-frame card text-texture allocations that motivated the
+`card_text_atlas` refactor), use heaptrack against a non-sanitized
+build:
+
+    sudo pacman -S heaptrack                 # Arch / Manjaro — heaptrack_gui
+                                             # ships in the same package
+    # Debian / Ubuntu may split the GUI into a separate heaptrack-gui
+    # package — adjust accordingly.
+    meson setup _build-release -Db_sanitize=none --buildtype=debug
+    meson compile -C _build-release
+
+Then under heaptrack:
+
+    heaptrack ./_build-release/dealers-choice --port 23999 --verbose
+
+Play the scenario you want to profile and quit cleanly (the X button
+or ESC, not `kill`).  heaptrack writes
+`heaptrack.dealers-choice.<pid>.zst` in the current directory.  Open
+it interactively:
+
+    heaptrack_gui heaptrack.dealers-choice.<pid>.zst
+
+Or text summary:
+
+    heaptrack_print heaptrack.dealers-choice.<pid>.zst | head -40
+
+Useful things to look at:
+
+- "MOST CALLS TO ALLOCATION FUNCTIONS" — top callstacks by allocation
+  count.  Per-frame work shows up here even when peak memory is fine.
+- The footer's "calls to allocation functions" rate (calls/s).
+  Anything above ~5k/s for a 2D card game is suspect.
+- "total memory leaked" — non-zero usually means
+  allocate-once-and-forget, not always a bug (think singletons), but
+  worth checking the callstacks.
+
+heaptrack is **not** part of `meson test` (it requires a real GUI
+session) and **not** a checkdepends; treat it as a manual investigation
+tool.
+
+(The `### What it stresses` section below belongs to the netem block
+above — keep that in mind when adding more profiling content here.)
+
+### What netem stresses
 
 - Connection handshake (SYN/ACK + DCPROTO header + nonce auth) under
   realistic latency — exposes any code path that assumed instant


### PR DESCRIPTION
card_widget_render was calling TTF_RenderUTF8_Blended + SDL_CreateTextureFromSurface + SDL_DestroyTexture every frame for every card on screen.  Heaptrack on a release-build, 2-hand 7-card stud session showed ~32k allocations/sec sustained, with card_widget_render → ui_widget_render → handle_game_logic as the #1 allocation callstack (6M of the 9M total allocations over 4 min of gameplay).

Pre-render all 52 (face, suit) text textures once after the renderer and FONT_CARD are ready, and have card_widget_render look them up by (face_val, suit) and SDL_RenderCopy.  CardWidget_t now stores face_val + suit; the atlas owns the textures.

Lifetime:
  - card_text_atlas_init() in main.c right after fonts open and the renderer is created.
  - card_text_atlas_destroy() in do_sdl_cleanup() right before SDL_DestroyRenderer — textures must outlive the renderer they were created with.

Heaptrack on the same 2-hand scenario:
  Before: 8.98M total allocs, 32k/s, peak RSS 137 MB
  After:  1.34M total allocs, 8.8k/s, peak RSS 138 MB

card_widget_render is no longer in the top allocation callstacks; remaining churn is all libgallium GPU driver work (per-frame buffer-swap) that app code can't influence.

Also adds a heaptrack profiling section to tests/README.md documenting the workflow that found the issue.