### PR TITLE
widgets: render card suit symbols from bundled SVGs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
 - (in-progress)
+  + Card suits rendered from bundled SVGs (data/images/suits/), sized larger
+    than the face letter for accessibility; --card-test opens an A+10 grid
   * regression fix: when a player times out during the discard phase the status
     message now correctly shows they drew 0 cards; the regression was introduced
     in 2fd55fb when explicit timeout handling was added to handle_draw() but the

--- a/data/images/suits/club.svg
+++ b/data/images/suits/club.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 32 32">
+  <g fill="#ffffff">
+    <circle cx="16" cy="9" r="6.5"/>
+    <circle cx="9" cy="20" r="6.5"/>
+    <circle cx="23" cy="20" r="6.5"/>
+    <path d="M 12 30 L 20 30 C 18 28, 17 25, 16 21 C 15 25, 14 28, 12 30 Z"/>
+  </g>
+</svg>

--- a/data/images/suits/diamond.svg
+++ b/data/images/suits/diamond.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 32 32">
+  <path d="M 16 1 L 30 16 L 16 31 L 2 16 Z" fill="#ffffff"/>
+</svg>

--- a/data/images/suits/heart.svg
+++ b/data/images/suits/heart.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 32 32">
+  <path d="M 16 28
+           C 16 28, 3 19, 3 10
+           C 3 5.5, 6.5 3, 10 3
+           C 13 3, 15 5.5, 16 8
+           C 17 5.5, 19 3, 22 3
+           C 25.5 3, 29 5.5, 29 10
+           C 29 19, 16 28, 16 28 Z"
+        fill="#ffffff"/>
+</svg>

--- a/data/images/suits/spade.svg
+++ b/data/images/suits/spade.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 32 32">
+  <g fill="#ffffff">
+    <!-- Body: lobes tucked in tighter so the stem below has room. -->
+    <path d="M 16 3
+             C 16 10, 28 13, 28 21
+             C 28 24, 25.5 26, 22.5 26
+             C 20 26, 18 25, 16 22
+             C 14 25, 12 26, 9.5 26
+             C 6.5 26, 4 24, 4 21
+             C 4 13, 16 10, 16 3 Z"/>
+    <!-- Stem: a touch wider and taller so it stands clear of the
+         body lobes; tiny outward flare at the base. -->
+    <path d="M 10 31 L 22 31
+             C 19 29, 17.5 26, 16 22
+             C 14.5 26, 13 29, 10 31 Z"/>
+  </g>
+</svg>

--- a/meson.build
+++ b/meson.build
@@ -102,9 +102,12 @@ dep_names = [
 
 # SDL2_ttf and SDL2_image are only used by the client (rendering); the bot
 # must not link against them or namcap/lintian will flag them as unused.
-client_only_dep_names = [
-  'SDL2_ttf',
-  'SDL2_image',
+# SDL2_image >= 2.0.5 is needed for IMG_LoadSVG_RW (used by the suit-symbol
+# atlas in src/widgets/card_text_atlas.c).  2.0.5 is what Ubuntu Jammy ships,
+# so this is the practical Linux floor.
+client_only_dep_names = ['SDL2_ttf']
+client_only_deps_versioned = [
+  ['SDL2_image', '>= 2.0.5'],
 ]
 
 # On Slackware, the miniaudio build fails (linking) if dl and threads aren't added here
@@ -122,6 +125,9 @@ endforeach
 client_only_deps = []
 foreach dep : client_only_dep_names
   client_only_deps += dependency(dep)
+endforeach
+foreach pair : client_only_deps_versioned
+  client_only_deps += dependency(pair[0], version: pair[1])
 endforeach
 
 shared_inc = [include_directories(['src', 'src/protobuf'])]

--- a/src/main.c
+++ b/src/main.c
@@ -44,6 +44,7 @@
 #include "server.h"
 #include "util.h"
 #include "widgets/button.h"
+#include "widgets/card.h"
 #include "widgets/card_text_atlas.h"
 #include "widgets/checkbox.h"
 #include "widgets/image.h"
@@ -671,6 +672,7 @@ static CliArgs_t parse_cli_args(int argc, char *argv[]) {
     OPT_DISABLE_TIMEOUT,
     OPT_AUTODEAL,
     OPT_AUTO_CONNECT,
+    OPT_CARD_TEST,
   };
 
   static const glopt_option_t options[] = {
@@ -688,6 +690,7 @@ static CliArgs_t parse_cli_args(int argc, char *argv[]) {
       {"disable-timeout", GLOPT_NO_ARG, OPT_DISABLE_TIMEOUT, 0},
       {"autodeal", GLOPT_NO_ARG, OPT_AUTODEAL, 0},
       {"auto-connect", GLOPT_NO_ARG, OPT_AUTO_CONNECT, 0},
+      {"card-test", GLOPT_NO_ARG, OPT_CARD_TEST, 0},
       {NULL, 0, 0, 0}};
 
   glopt_parser_t parser;
@@ -747,27 +750,100 @@ static CliArgs_t parse_cli_args(int argc, char *argv[]) {
     case OPT_AUTO_CONNECT:
       cli_args.auto_connect = true;
       break;
+    case OPT_CARD_TEST:
+      cli_args.card_test = true;
+      break;
     case '?':
     default:
       print_version();
       fputs("Usage:\n"
             "  --verbose\n"
             "  --server-log-game-results [path/to/file]\n"
-            "  --server-log-hands [path/to/file]\n"
             "  --server-conf [Path to alternate server config file]\n"
             "  --bind-address [IP]        Address for the server to bind to (default: all "
             "interfaces)\n"
             "  --host [IP]\n"
             "  --port [port]\n"
             "  --disable-audio\n"
+            "  --version\n"
+            "\n"
+            "Testing options:\n"
+            "  --server-log-hands [path/to/file]\n"
             "  --disable-timeout          Server will not disconnect players who exceed the action "
             "timeout threshold\n"
-            "  --version\n",
+            "  --card-test                Open a window showing A and 10 of each suit; x/ESC to exit\n",
             stderr);
       exit(EXIT_FAILURE);
     }
   }
   return cli_args;
+}
+
+/* --card-test mode: open the SDL window, render the A and 10 of each
+ * suit in a 2x4 grid on the green felt, and wait for x / ESC / window
+ * close.  Lets you iterate on suit size, position, and font without
+ * spinning up a server and a bot for every visual check. */
+static int run_card_test(SdlContext_t *sdl_context, Font_t *font, Path_t *path) {
+  char felt_path[4096];
+  snprintf(felt_path, sizeof(felt_path), "%s/images/100x100-green-felt-seamless-tile.png",
+           path->data);
+  SDL_Texture *felt_tex = load_texture(sdl_context->renderer, felt_path);
+
+  static const struct {
+    int face;
+    int suit;
+  } TEST_CARDS[8] = {
+      {DH_CARD_ACE, DH_SUIT_SPADES}, {DH_CARD_ACE, DH_SUIT_HEARTS},
+      {DH_CARD_ACE, DH_SUIT_DIAMONDS}, {DH_CARD_ACE, DH_SUIT_CLUBS},
+      {DH_CARD_TEN, DH_SUIT_SPADES}, {DH_CARD_TEN, DH_SUIT_HEARTS},
+      {DH_CARD_TEN, DH_SUIT_DIAMONDS}, {DH_CARD_TEN, DH_SUIT_CLUBS},
+  };
+
+  const int gap = 24;
+  const int cw_w = g_layout_cfg.card_w;
+  const int cw_h = g_layout_cfg.card_h;
+  const int grid_w = 4 * cw_w + 3 * gap;
+  const int grid_h = 2 * cw_h + gap;
+  const int origin_x = LOGICAL_WIDTH / 2 - grid_w / 2;
+  const int origin_y = LOGICAL_HEIGHT / 2 - grid_h / 2;
+
+  CardWidget_t cards[8];
+  for (int i = 0; i < 8; i++) {
+    int row = i / 4;
+    int col = i % 4;
+    card_widget_init(&cards[i], font->fonts[FONT_CARD]);
+    cards[i].base.rect.x = origin_x + col * (cw_w + gap);
+    cards[i].base.rect.y = origin_y + row * (cw_h + gap);
+    cards[i].face_val = TEST_CARDS[i].face;
+    cards[i].suit = TEST_CARDS[i].suit;
+  }
+
+  bool running = true;
+  while (running) {
+    SDL_Event ev;
+    while (SDL_PollEvent(&ev)) {
+      if (ev.type == SDL_QUIT)
+        running = false;
+      else if (ev.type == SDL_KEYDOWN &&
+               (ev.key.keysym.sym == SDLK_x || ev.key.keysym.sym == SDLK_ESCAPE))
+        running = false;
+    }
+
+    SDL_SetRenderDrawColor(sdl_context->renderer, 0, 100, 0, 255);
+    SDL_RenderClear(sdl_context->renderer);
+    if (felt_tex)
+      draw_felt_background(sdl_context->renderer, felt_tex);
+
+    for (int i = 0; i < 8; i++)
+      cards[i].base.render(&cards[i].base);
+
+    SDL_RenderPresent(sdl_context->renderer);
+    SDL_Delay(16);
+  }
+
+  if (felt_tex)
+    SDL_DestroyTexture(felt_tex);
+  return 0;
 }
 
 static void init_sdl_window(SdlContext_t *c, const char *title) {
@@ -829,24 +905,17 @@ int main(int argc, char *argv[]) {
 
   const CliArgs_t cli_args = parse_cli_args(argc, argv);
 
-  if (sodium_init() < 0) {
-    fprintf(stderr, "libsodium init failed\n");
-    exit(1);
-  }
-
-  pcg_srand_auto();
-
   if (cli_args.run_server_flag) {
+    if (sodium_init() < 0) {
+      fprintf(stderr, "libsodium init failed\n");
+      exit(1);
+    }
+    pcg_srand_auto();
     return run_server(&cli_args, &path);
   }
 
   if (SDL_Init(SDL_INIT_VIDEO) == -1) {
     fprintf(stderr, "SDL init failed: %s\n", SDL_GetError());
-    return 1;
-  }
-  if (tcpme_init() != 0) {
-    fprintf(stderr, "tcpme_init failed: %s\n", tcpme_get_error());
-    SDL_Quit();
     return 1;
   }
 
@@ -895,7 +964,27 @@ int main(int argc, char *argv[]) {
    * TTF_RenderUTF8_Blended + SDL_CreateTextureFromSurface every frame
    * for every card (~6M allocations per 4 min of gameplay before this
    * cache landed). */
-  card_text_atlas_init(sdl_context.renderer, font.fonts[FONT_CARD]);
+  card_text_atlas_init(sdl_context.renderer, font.fonts[FONT_CARD], path.data);
+
+  if (cli_args.card_test) {
+    int rc = run_card_test(&sdl_context, &font, &path);
+    for (int i = 0; i < NUM_FONTS; ++i)
+      TTF_CloseFont(font.fonts[i]);
+    TTF_Quit();
+    do_sdl_cleanup(&sdl_context);
+    return rc;
+  }
+
+  /* Client networking + password hashing — only needed past this point. */
+  if (sodium_init() < 0) {
+    fprintf(stderr, "libsodium init failed\n");
+    exit(1);
+  }
+  pcg_srand_auto();
+  if (tcpme_init() != 0) {
+    fprintf(stderr, "tcpme_init failed: %s\n", tcpme_get_error());
+    return 1;
+  }
 
 #ifdef ENABLE_NLS
   if (strlen(player_config.language) != 0) {

--- a/src/main.h
+++ b/src/main.h
@@ -39,6 +39,7 @@ typedef struct {
   bool disable_timeout;
   bool autodeal;
   bool auto_connect;
+  bool card_test;
 } CliArgs_t;
 
 #endif

--- a/src/widgets/card.c
+++ b/src/widgets/card.c
@@ -32,6 +32,7 @@
 
 #include "card.h"
 #include "card_text_atlas.h"
+#include "deckhandler.h"
 #include "globals.h"
 #include "graphics.h"
 #include "util.h"
@@ -532,22 +533,42 @@ static void card_widget_render(UIWidget_t *w) {
   SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
   SDL_RenderDrawRect(renderer, &w->rect);
 
-  /* Look up the pre-rendered text texture from the atlas built at GUI
-   * startup.  Replaces the per-frame TTF_RenderUTF8_Blended +
-   * SDL_CreateTextureFromSurface that used to be here — that path was
-   * the #1 allocator in heaptrack profiles, ~6M calls / 4 min of
-   * gameplay. */
-  int text_w = 0, text_h = 0;
-  SDL_Texture *text_texture = card_text_atlas_get(cw->face_val, cw->suit, &text_w, &text_h);
-  if (!text_texture) {
-    /* Either the atlas wasn't initialised or the face/suit pair is
-     * out of range.  Either way an empty card face is the safe
-     * fallback; the card border is already drawn. */
+  /* Look up the pre-rendered face + suit textures from the atlas built
+   * at GUI startup.  Face is TTF-rendered with the suit colour baked
+   * in; suit is loaded white-on-transparent from SVG and tinted here
+   * via SDL_SetTextureColorMod.  The suit texture is oversized (96px
+   * native) and rendered at a smaller display size below — SDL
+   * downscales it cleanly each frame. */
+  CardAtlasEntry_t entry;
+  if (!card_text_atlas_get(cw->face_val, cw->suit, &entry)) {
     return;
   }
-  SDL_Rect textRect = {w->rect.x + (g_layout_cfg.card_w - text_w) / 2,
-                       w->rect.y + (g_layout_cfg.card_h - text_h) / 2, text_w, text_h};
-  SDL_RenderCopy(renderer, text_texture, NULL, &textRect);
+  int gap = 2;
+  /* Suit display size: 3/5 of card height, square aspect.  Bigger
+   * than the face letter so the suit reads at a glance, but with
+   * enough card-edge margin not to feel crowded. */
+  const int suit_disp = (g_layout_cfg.card_h * 3) / 5;
+  int pair_w = entry.face_w + gap + suit_disp;
+  int pair_x = w->rect.x + (g_layout_cfg.card_w - pair_w) / 2;
+  /* Keep at least a small left margin on wide faces ("10") that would
+   * otherwise sit flush against the card border once centered.  When
+   * we clamp, also pull the suit closer to the face so the card
+   * doesn't crowd the right edge either. */
+  const int min_left_margin = 5;
+  if (pair_x - w->rect.x < min_left_margin) {
+    pair_x = w->rect.x + min_left_margin;
+    gap = 0;
+  }
+  SDL_Rect face_rect = {pair_x, w->rect.y + (g_layout_cfg.card_h - entry.face_h) / 2,
+                        entry.face_w, entry.face_h};
+  SDL_Rect suit_rect = {pair_x + entry.face_w + gap,
+                        w->rect.y + (g_layout_cfg.card_h - suit_disp) / 2, suit_disp, suit_disp};
+  SDL_RenderCopy(renderer, entry.face, NULL, &face_rect);
+  if (cw->suit == DH_SUIT_HEARTS || cw->suit == DH_SUIT_DIAMONDS)
+    SDL_SetTextureColorMod(entry.suit, 200, 0, 0);
+  else
+    SDL_SetTextureColorMod(entry.suit, 0, 0, 0);
+  SDL_RenderCopy(renderer, entry.suit, NULL, &suit_rect);
 }
 
 static void card_widget_destroy(UIWidget_t *w) { free(w); }

--- a/src/widgets/card_text_atlas.c
+++ b/src/widgets/card_text_atlas.c
@@ -31,110 +31,177 @@
 #include "deckhandler.h"
 #include "style.h"
 
+#include <SDL2/SDL_image.h>
 #include <stdio.h>
 
-/* Atlas storage: indexed by [face_val][suit].  face_val runs 1..13
- * (DH_CARD_ACE..DH_CARD_KING) so we waste slot [0]; that's 13 * 4 *
- * sizeof(SDL_Texture*) = 416 bytes of wasted CPU pointers, negligible
- * vs the alternative of subtracting 1 every lookup and making the
- * code harder to read. */
-#define ATLAS_FACES 15 /* 0..14 inclusive, indices 1..13 used */
+#define ATLAS_FACES 15 /* indices 1..13 used; slot 0 wasted */
+#define ATLAS_COLORS 2 /* 0 = black (spades/clubs), 1 = red (hearts/diamonds) */
 #define ATLAS_SUITS 4
 
 static struct {
   SDL_Texture *texture;
   int w, h;
-} g_atlas[ATLAS_FACES][ATLAS_SUITS];
+} g_face_atlas[ATLAS_FACES][ATLAS_COLORS];
+
+static struct {
+  SDL_Texture *texture;
+  int w, h;
+} g_suit_atlas[ATLAS_SUITS];
 
 static bool g_initialised = false;
 static SDL_Renderer *g_renderer = NULL;
-static TTF_Font *g_font = NULL;
+static TTF_Font *g_face_font = NULL;
+
+static int color_idx_for_suit(int suit) {
+  return (suit == DH_SUIT_HEARTS || suit == DH_SUIT_DIAMONDS) ? 1 : 0;
+}
+
+/* Maps DH_SUIT_* to the corresponding SVG filename under
+ * data/images/suits/. */
+static const char *suit_svg_name(int suit) {
+  switch (suit) {
+  case DH_SUIT_HEARTS:
+    return "heart.svg";
+  case DH_SUIT_DIAMONDS:
+    return "diamond.svg";
+  case DH_SUIT_SPADES:
+    return "spade.svg";
+  case DH_SUIT_CLUBS:
+    return "club.svg";
+  default:
+    return NULL;
+  }
+}
 
 static void destroy_locked(void) {
   for (int f = 0; f < ATLAS_FACES; f++)
-    for (int s = 0; s < ATLAS_SUITS; s++) {
-      if (g_atlas[f][s].texture) {
-        SDL_DestroyTexture(g_atlas[f][s].texture);
-        g_atlas[f][s].texture = NULL;
+    for (int c = 0; c < ATLAS_COLORS; c++) {
+      if (g_face_atlas[f][c].texture) {
+        SDL_DestroyTexture(g_face_atlas[f][c].texture);
+        g_face_atlas[f][c].texture = NULL;
       }
-      g_atlas[f][s].w = g_atlas[f][s].h = 0;
+      g_face_atlas[f][c].w = g_face_atlas[f][c].h = 0;
     }
+  for (int s = 0; s < ATLAS_SUITS; s++) {
+    if (g_suit_atlas[s].texture) {
+      SDL_DestroyTexture(g_suit_atlas[s].texture);
+      g_suit_atlas[s].texture = NULL;
+    }
+    g_suit_atlas[s].w = g_suit_atlas[s].h = 0;
+  }
 }
 
-void card_text_atlas_init(SDL_Renderer *renderer, TTF_Font *font) {
-  /* If already initialised for the same font, no-op so callers can
-   * be defensive without burning cycles. */
-  if (g_initialised && g_renderer == renderer && g_font == font)
+void card_text_atlas_init(SDL_Renderer *renderer, TTF_Font *face_font, const char *data_dir) {
+  if (g_initialised && g_renderer == renderer && g_face_font == face_font)
     return;
   destroy_locked();
   g_renderer = renderer;
-  g_font = font;
+  g_face_font = face_font;
   g_initialised = false;
+
+  /* Same color convention as make_human_readable_card in src/client.c:
+   * red for hearts and diamonds, black for spades and clubs. */
+  const SDL_Color colors[ATLAS_COLORS] = {
+      [0] = {0, 0, 0, 255},
+      [1] = {200, 0, 0, 255},
+  };
 
   for (int face = DH_CARD_ACE; face <= DH_CARD_KING; face++) {
     const char *face_str = DH_get_card_face_str(face);
     if (!face_str)
       continue;
-    for (int suit = 0; suit < ATLAS_SUITS; suit++) {
-      DH_Card card = {.face_val = face, .suit = suit};
-      const char *suit_str = DH_get_card_unicode_suit(card);
-      if (!suit_str)
-        continue;
-      char text[24];
-      snprintf(text, sizeof(text), "%s%s", face_str, suit_str);
-
-      /* Same color convention as make_human_readable_card in
-       * src/client.c: red for hearts and diamonds, black for spades
-       * and clubs.  Kept inline rather than via get_color() to avoid
-       * an interface cycle with the styles config. */
-      SDL_Color color = (suit == DH_SUIT_HEARTS || suit == DH_SUIT_DIAMONDS)
-                            ? (SDL_Color){200, 0, 0, 255}
-                            : (SDL_Color){0, 0, 0, 255};
-
-      SDL_Surface *surface = TTF_RenderUTF8_Blended(font, text, color);
+    for (int c = 0; c < ATLAS_COLORS; c++) {
+      SDL_Surface *surface = TTF_RenderUTF8_Blended(face_font, face_str, colors[c]);
       if (!surface) {
-        fprintf(stderr, "card_text_atlas_init: TTF_RenderUTF8_Blended(%s) failed: %s\n",
-                text, TTF_GetError());
+        fprintf(stderr, "card_text_atlas_init: face render (%s) failed: %s\n", face_str,
+                TTF_GetError());
         continue;
       }
       SDL_Texture *texture = SDL_CreateTextureFromSurface(renderer, surface);
       if (!texture) {
-        fprintf(stderr, "card_text_atlas_init: SDL_CreateTextureFromSurface(%s) failed: %s\n",
-                text, SDL_GetError());
+        fprintf(stderr, "card_text_atlas_init: face texture (%s) failed: %s\n", face_str,
+                SDL_GetError());
         SDL_FreeSurface(surface);
         continue;
       }
-      g_atlas[face][suit].texture = texture;
-      g_atlas[face][suit].w = surface->w;
-      g_atlas[face][suit].h = surface->h;
+      g_face_atlas[face][c].texture = texture;
+      g_face_atlas[face][c].w = surface->w;
+      g_face_atlas[face][c].h = surface->h;
       SDL_FreeSurface(surface);
     }
   }
+
+  /* Load each suit SVG white-on-transparent.  The SVG files bake in
+   * width/height attributes (currently 96×96) — chosen oversize so
+   * SDL downscales them cleanly to whatever display size card.c
+   * picks, and so they stay crisp in fullscreen / high-DPI modes
+   * where SDL_RenderSetLogicalSize would otherwise upscale a
+   * smaller-rasterised texture.  card_widget_render applies the
+   * per-suit colour via SDL_SetTextureColorMod, so one texture
+   * serves both red and black variants. */
+  for (int suit = 0; suit < ATLAS_SUITS; suit++) {
+    const char *svg_name = suit_svg_name(suit);
+    if (!svg_name)
+      continue;
+    char path[4096];
+    snprintf(path, sizeof(path), "%s/images/suits/%s", data_dir, svg_name);
+    SDL_RWops *rw = SDL_RWFromFile(path, "rb");
+    if (!rw) {
+      fprintf(stderr, "card_text_atlas_init: open %s failed: %s\n", path, SDL_GetError());
+      continue;
+    }
+    SDL_Surface *surface = IMG_LoadSVG_RW(rw);
+    SDL_RWclose(rw);
+    if (!surface) {
+      fprintf(stderr, "card_text_atlas_init: IMG_LoadSizedSVG_RW(%s) failed: %s\n", path,
+              IMG_GetError());
+      continue;
+    }
+    SDL_Texture *texture = SDL_CreateTextureFromSurface(renderer, surface);
+    if (!texture) {
+      fprintf(stderr, "card_text_atlas_init: suit texture (%s) failed: %s\n", svg_name,
+              SDL_GetError());
+      SDL_FreeSurface(surface);
+      continue;
+    }
+    /* Enable color mod + alpha blending so card_widget_render can
+     * tint the white SVG to the suit colour each frame. */
+    SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
+    g_suit_atlas[suit].texture = texture;
+    g_suit_atlas[suit].w = surface->w;
+    g_suit_atlas[suit].h = surface->h;
+    SDL_FreeSurface(surface);
+  }
+
   g_initialised = true;
 }
 
 void card_text_atlas_destroy(void) {
   destroy_locked();
   g_renderer = NULL;
-  g_font = NULL;
+  g_face_font = NULL;
   g_initialised = false;
 }
 
-SDL_Texture *card_text_atlas_get(int face_val, int suit_val, int *out_w, int *out_h) {
-  if (!g_initialised)
-    return NULL;
+bool card_text_atlas_get(int face_val, int suit_val, CardAtlasEntry_t *out) {
+  if (!g_initialised || !out)
+    return false;
   if (face_val < DH_CARD_ACE || face_val > DH_CARD_KING)
-    return NULL;
+    return false;
   if (suit_val < 0 || suit_val >= ATLAS_SUITS)
-    return NULL;
-  SDL_Texture *t = g_atlas[face_val][suit_val].texture;
-  if (!t)
-    return NULL;
-  if (out_w)
-    *out_w = g_atlas[face_val][suit_val].w;
-  if (out_h)
-    *out_h = g_atlas[face_val][suit_val].h;
-  return t;
+    return false;
+  int c = color_idx_for_suit(suit_val);
+  SDL_Texture *face = g_face_atlas[face_val][c].texture;
+  SDL_Texture *suit = g_suit_atlas[suit_val].texture;
+  if (!face || !suit)
+    return false;
+  out->face = face;
+  out->face_w = g_face_atlas[face_val][c].w;
+  out->face_h = g_face_atlas[face_val][c].h;
+  out->suit = suit;
+  out->suit_w = g_suit_atlas[suit_val].w;
+  out->suit_h = g_suit_atlas[suit_val].h;
+  return true;
 }
 
 bool card_text_atlas_is_initialised(void) { return g_initialised; }

--- a/src/widgets/card_text_atlas.h
+++ b/src/widgets/card_text_atlas.h
@@ -33,23 +33,43 @@
 #include <SDL2/SDL_ttf.h>
 #include <stdbool.h>
 
-/* Builds a per-(face, suit) text texture for every card in the deck and
- * caches them for the lifetime of the GUI session.  Replaces the
- * per-frame TTF_RenderUTF8_Blended + SDL_CreateTextureFromSurface
- * pair that card_widget_render used to do — now that path is a single
- * lookup + SDL_RenderCopy per card per frame, zero allocations.
+/* Returned by card_text_atlas_get: the two pre-rendered textures and
+ * their dimensions.  card_widget_render lays them out side-by-side
+ * (face on the left, suit on the right, pair centered in the card
+ * rect).
  *
- * Must be called after SDL + TTF are initialised and after the
- * renderer + font are created.  Safe to call multiple times
- * (subsequent calls reuse the existing atlas if the font hasn't
- * changed; pass a different font to rebuild).
+ * Suit textures are loaded white-on-transparent from SVG and tinted
+ * to red or black per suit via SDL_SetTextureColorMod at render time.
+ * Face textures are TTF-rendered and already coloured per suit. */
+typedef struct {
+  SDL_Texture *face;
+  SDL_Texture *suit;
+  int face_w, face_h;
+  int suit_w, suit_h;
+} CardAtlasEntry_t;
+
+/* Builds two atlases:
  *
- * `font` is the TTF_Font used for card faces — typically
- * font->fonts[FONT_CARD] in the client.  The atlas does NOT take
- * ownership of the font or renderer; callers retain responsibility
- * for those.
- */
-void card_text_atlas_init(SDL_Renderer *renderer, TTF_Font *font);
+ *   - face_atlas[13][2]  — face glyph ("A","2",...,"K") in black and
+ *                          red, TTF-rendered with `face_font`.  Index
+ *                          is (face_val, color_idx) where color_idx
+ *                          = 1 for hearts/diamonds, 0 for spades/clubs.
+ *
+ *   - suit_atlas[4]      — suit symbol (♠/♥/♦/♣) loaded from
+ *                          `data_dir`/images/suits/{spade,heart,
+ *                          diamond,club}.svg via IMG_LoadSizedSVG_RW.
+ *                          Rendered white-on-transparent; the colour
+ *                          is applied per-render via
+ *                          SDL_SetTextureColorMod.
+ *
+ * 26 + 4 = 30 textures total.
+ *
+ * Must be called after SDL + TTF + SDL_image + the renderer are up
+ * and after the face font is open.  Safe to call multiple times —
+ * subsequent calls reuse the existing atlas if the inputs are
+ * unchanged.  The atlas does NOT take ownership of the font or
+ * renderer. */
+void card_text_atlas_init(SDL_Renderer *renderer, TTF_Font *face_font, const char *data_dir);
 
 /* Frees every cached texture and resets the atlas.  Call before
  * destroying the SDL_Renderer the atlas was initialised with —
@@ -57,28 +77,22 @@ void card_text_atlas_init(SDL_Renderer *renderer, TTF_Font *font);
  * undefined behavior. */
 void card_text_atlas_destroy(void);
 
-/* Returns the cached texture for the given face/suit pair, plus its
- * pixel dimensions.  Returns NULL (with *out_w / *out_h untouched)
- * when:
+/* Populates *out with the face + suit textures for the given card.
+ * Returns false (with *out untouched) when:
  *   - the atlas hasn't been initialised yet,
  *   - the (face_val, suit) is outside the dealt range
  *     (face_val 1..13, suit 0..3),
- *   - or the initial render for this card failed and the slot is
- *     empty.  Callers should fall back to a draw-time render in that
- *     case (or, more typically, treat it as a fatal init bug).
+ *   - or either of the initial loads for this card failed.
  *
- * The returned texture is owned by the atlas — do not call
- * SDL_DestroyTexture on it. */
-SDL_Texture *card_text_atlas_get(int face_val, int suit_val, int *out_w, int *out_h);
+ * The returned textures are owned by the atlas — do not call
+ * SDL_DestroyTexture on them. */
+bool card_text_atlas_get(int face_val, int suit_val, CardAtlasEntry_t *out);
 
-/* True once card_text_atlas_init has succeeded.  Tests and asserts
- * use this to confirm the lifecycle without leaking the internal
- * static arrays. */
+/* True once card_text_atlas_init has succeeded. */
 bool card_text_atlas_is_initialised(void);
 
-/* Total number of textures the atlas holds when fully populated.
- * 13 faces × 4 suits = 52.  Exposed for tests so they don't have to
- * encode the constant separately. */
-#define CARD_TEXT_ATLAS_SIZE 52
+/* Total textures the atlas holds when fully populated: 13 faces × 2
+ * colors + 4 suits = 30. */
+#define CARD_TEXT_ATLAS_SIZE 30
 
 #endif


### PR DESCRIPTION
Replace TTF-rendered Unicode suit glyphs (♠♥♦♣) with custom SVGs shipped under data/images/suits/.  Suit graphics are now under our visual control and consistent across platforms / fonts; SVGs are rasterised once at GUI startup via IMG_LoadSVG_RW and tinted to red or black at render time via SDL_SetTextureColorMod (so one texture per suit, not per colour).

Each SVG is rendered at 96×96 native and downscaled to 2/3 of card height (~33px in the current 80×50 layout).  Oversize source keeps the suit crisp under SDL's fullscreen / logical-size upscaling.

Also adds --card-test, a display-only CLI mode that opens a window showing A and 10 of each suit on green felt (x/ESC to exit) so the SVG paths can be iterated visually without spinning up a server + bot.  Skips sodium and tcpme init since neither is needed for a pure-rendering view.

meson: SDL2_image is now required at >= 2.0.5 (Ubuntu Jammy's version) for IMG_LoadSVG_RW; previously the dep was unversioned.