### PR TITLE
windows: embed app icon into dealers-choice.exe

### DIFF
--- a/icons/dealers-choice.rc
+++ b/icons/dealers-choice.rc
@@ -1,0 +1,1 @@
+1 ICON "dealers-choice.ico"

--- a/meson.build
+++ b/meson.build
@@ -187,9 +187,18 @@ bot_dep = declare_dependency(
   include_directories: [shared_inc, include_directories('.')],
 )
 
+exe_sources = ['src/main.c']
+if platform_is_windows
+  windows = import('windows')
+  exe_sources += windows.compile_resources(
+    'icons/dealers-choice.rc',
+    depend_files: ['icons/dealers-choice.ico'],
+  )
+endif
+
 exe_target = executable(
   meson.project_name(),
-  ['src/main.c'],
+  exe_sources,
   dependencies: game_dep,
   install: true,
 )


### PR DESCRIPTION
The Inno Setup installer set the icon on the installer and Start Menu shortcut, but the executable itself had no embedded icon, so Explorer / taskbar / manual shortcuts fell back to the generic Windows app icon.

Refs #262