### PR TITLE
Add round-opener marker (Fixes #264)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@
     accessibility (--card-test opens an A+10 grid)
   + Game-play action hotkeys are now configurable via a press-to-bind Hotkeys
     screen (Settings > Hotkeys), persisted in player.conf (#102)
+  + The seat that opens each betting round is marked in its nameplate (#264)
   * regression fix: when a player times out during the discard phase the status
     message now correctly shows they drew 0 cards; the regression was introduced
     in 2fd55fb when explicit timeout handling was added to handle_draw() but the

--- a/src/client.c
+++ b/src/client.c
@@ -1197,6 +1197,11 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
       "You may only discard a maximum of 3 cards", font->fonts[FONT_BOLD], DC_DISCARD_TEXT);
   uint8_t last_max_allowed = 3;
 
+  /* Per-seat glyph marking who opens the current betting round; sits in the
+   * nameplate's left padding, just left of the nick. */
+  TextWidget_t *opener_tag =
+      text_widget_create("{}", font->fonts[FONT_BOLD], (SDL_Color){255, 140, 0, 255});
+
   static const SDL_Keycode bet_hotkeys[MAX_BET_AMOUNTS] = {
       SDLK_1, SDLK_2, SDLK_3, SDLK_4, SDLK_5, SDLK_6, SDLK_7, SDLK_8,
   };
@@ -1587,6 +1592,9 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
     const int np_pad = g_layout_cfg.nameplate_pad;
     const int col_spacing_val = 20; // matches ui_table_begin default
     int total_max_w = max_col_w[0] + max_col_w[1] + max_col_w[2] + 2 * col_spacing_val;
+    /* Reserved zone on the left of every nameplate for the round-opener glyph,
+     * so it sits clear of the turn outline (which hugs the content). */
+    const int opener_gutter = 14;
     SDL_Rect turn_outline = {0};
     SDL_Rect nameplate_rects[MAX_PLAYERS] = {0};
     for (int8_t id = 0; id < MAX_PLAYERS; id++) {
@@ -1595,7 +1603,7 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
       UITable_t player_table = {0};
       /* Local player's nameplate centers on the window; opponents anchor to
        * their (left-origin) card row. */
-      int np_origin_x = (id == my_id) ? g_layout.local_seat.x - total_max_w / 2
+      int np_origin_x = (id == my_id) ? g_layout.local_seat.x - total_max_w / 2 + opener_gutter / 2
                                       : seat_pos[id].x + g_layout_cfg.card_w / 2;
       ui_table_begin(&player_table, np_origin_x,
                      seat_pos[id].y + (int)(g_layout_cfg.card_h * 1.2), 3);
@@ -1607,8 +1615,8 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
       ui_table_add(&player_table, 0, 2, &game_coins_tw[id]->base);
       ui_table_layout(&player_table);
       nameplate_rects[id] =
-          (SDL_Rect){player_table.x - np_pad, player_table.y - np_pad, total_max_w + np_pad * 2,
-                     player_table.row_height[0] + np_pad * 2};
+          (SDL_Rect){player_table.x - np_pad - opener_gutter, player_table.y - np_pad,
+                     total_max_w + np_pad * 2 + opener_gutter, player_table.row_height[0] + np_pad * 2};
       if (id == turn->id && !game_state->winner_declared) {
         const int pad = 4;
         turn_outline = (SDL_Rect){player_table.x - pad, player_table.y - pad, total_max_w + pad * 2,
@@ -1643,6 +1651,18 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
     if (turn_outline.w > 0) {
       SDL_SetRenderDrawColor(sdl_context->renderer, 255, 215, 0, 255);
       draw_rect_border(sdl_context->renderer, turn_outline);
+    }
+
+    if (game_state->round_opener_id >= 0 && game_state->round_opener_id < MAX_PLAYERS &&
+        nameplate_rects[game_state->round_opener_id].w > 0) {
+      SDL_Rect np = nameplate_rects[game_state->round_opener_id];
+      /* Center the glyph in the gutter left of where the turn outline sits
+       * (the outline's left edge is at content.x - 4 = np.x + zone_w). */
+      int zone_w = np_pad + opener_gutter - 4;
+      int opener_x = np.x + (zone_w - opener_tag->base.rect.w) / 2;
+      int opener_y = np.y + (np.h - opener_tag->base.rect.h) / 2;
+      ui_widget_place(&opener_tag->base, opener_x, opener_y);
+      ui_widget_render(&opener_tag->base);
     }
 
     /* Game indicators: two equal cells stacked vertically in the bottom-right
@@ -2160,6 +2180,7 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
   for (int i = 0; i < MAX_ACTIONS; i++)
     ui_widget_destroy(&action_bw[i]->base);
   ui_widget_destroy(&discard_hint_tw->base);
+  ui_widget_destroy(&opener_tag->base);
   step_scale_destroy(bet_scale);
   for (int i = 0; i < SIZEOF_STATUS_MSGS; i++)
     ui_widget_destroy(&status_tw[i]->base);

--- a/src/net.c
+++ b/src/net.c
@@ -88,6 +88,7 @@ uint8_t *serialize_game_state(const GameState_t *src, uint32_t *size_out) {
   // Pot
   msg.pot = src->pot;
   msg.dealer_id = src->dealer_id;
+  msg.round_opener_id = src->round_opener_id;
   msg.at_menu = src->at_menu;
   msg.raises_remaining = src->raises_remaining;
   msg.prev_bet_amount = src->prev_bet_amount;
@@ -126,6 +127,7 @@ bool deserialize_game_state(const uint8_t *data, uint32_t size, GameState_t *out
 
   out->pot = msg->pot;
   out->dealer_id = (int8_t)msg->dealer_id;
+  out->round_opener_id = (int8_t)msg->round_opener_id;
   out->at_menu = msg->at_menu;
   out->raises_remaining = msg->raises_remaining;
   out->prev_bet_amount = msg->prev_bet_amount;

--- a/src/netpoker.proto
+++ b/src/netpoker.proto
@@ -30,6 +30,7 @@ message GameState {
   bool winner_declared = 7;
   reserved 8;
   repeated Player player = 9;
+  int32 round_opener_id = 10;
 }
 
 message GameSettings {

--- a/src/protobuf/netpoker.pb-c.c
+++ b/src/protobuf/netpoker.pb-c.c
@@ -630,7 +630,7 @@ const ProtobufCMessageDescriptor player__descriptor =
   (ProtobufCMessageInit) player__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor game_state__field_descriptors[8] =
+static const ProtobufCFieldDescriptor game_state__field_descriptors[9] =
 {
   {
     "pot",
@@ -728,6 +728,18 @@ static const ProtobufCFieldDescriptor game_state__field_descriptors[8] =
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
+  {
+    "round_opener_id",
+    10,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_INT32,
+    0,   /* quantifier_offset */
+    offsetof(GameState, round_opener_id),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
 };
 static const unsigned game_state__field_indices_by_name[] = {
   2,   /* field[2] = at_menu */
@@ -737,13 +749,14 @@ static const unsigned game_state__field_indices_by_name[] = {
   0,   /* field[0] = pot */
   5,   /* field[5] = prev_bet_amount */
   4,   /* field[4] = raises_remaining */
+  8,   /* field[8] = round_opener_id */
   6,   /* field[6] = winner_declared */
 };
 static const ProtobufCIntRange game_state__number_ranges[2 + 1] =
 {
   { 1, 0 },
   { 9, 7 },
-  { 0, 8 }
+  { 0, 9 }
 };
 const ProtobufCMessageDescriptor game_state__descriptor =
 {
@@ -753,7 +766,7 @@ const ProtobufCMessageDescriptor game_state__descriptor =
   "GameState",
   "",
   sizeof(GameState),
-  8,
+  9,
   game_state__field_descriptors,
   game_state__field_indices_by_name,
   2,  game_state__number_ranges,

--- a/src/protobuf/netpoker.pb-c.h
+++ b/src/protobuf/netpoker.pb-c.h
@@ -88,10 +88,11 @@ struct  GameState
   protobuf_c_boolean winner_declared;
   size_t n_player;
   Player **player;
+  int32_t round_opener_id;
 };
 #define GAME_STATE__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&game_state__descriptor) \
-, 0, 0, 0, 0, 0, 0, 0, 0,NULL }
+, 0, 0, 0, 0, 0, 0, 0, 0,NULL, 0 }
 
 
 struct  GameSettings

--- a/src/server.c
+++ b/src/server.c
@@ -238,6 +238,7 @@ ServerConfig_t init_game_state(GameState_t *game_state, Path_t *path, const CliA
   }
 
   game_state->dealer_id = 0;
+  game_state->round_opener_id = -1;
   game_state->at_menu = true;
   game_state->player_count = 0;
   game_state->raises_remaining = 0;
@@ -988,6 +989,7 @@ static RoundResults handle_round_real(ArgsBroadcastGameState_t *args, uint32_t i
   RoundResults results = {0};
 
   turn = *args->starting_turn;
+  args->game_state->round_opener_id = (int8_t)turn->id;
   uint32_t total_bets_plus_raises = initial_bet;
   uint32_t player_total_paid[MAX_PLAYERS] = {0};
   if (initial_paid_id >= 0 && initial_paid_id < MAX_PLAYERS)
@@ -1774,6 +1776,7 @@ static void play_game(ArgsBroadcastGameState_t *args, DH_Deck *deck) {
 
   args->game_state->winner_declared = false;
   args->game_state->prev_bet_amount = 0;
+  args->game_state->round_opener_id = -1;
   args->game_state->player_count = count_active_clients(args->slot_taken);
   verbose_printf("player count: %d\n", args->game_state->player_count);
   args->game_state->winner_declared = false;

--- a/src/types.h
+++ b/src/types.h
@@ -81,6 +81,7 @@ typedef struct {
 typedef struct {
   uint32_t pot;
   int8_t dealer_id;
+  int8_t round_opener_id; /* seat that opens the current betting round (-1 = none) */
   bool at_menu;
   uint8_t player_count;
   uint32_t raises_remaining;


### PR DESCRIPTION
> Commit message drafted by Claude (Opus 4.8), an LLM by Anthropic, at @andy5995's direction.

Server tracks the seat that opens each betting round in a new GameState.round_opener_id field; the client marks it with an orange {} glyph in the opener's nameplate, left of the turn outline.