### PR TITLE
server/client: timestamped diagnostic logging + network-health warnin…

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,9 @@
   + Configurable game-play action hotkeys via a press-to-bind Hotkeys screen
     (#102)
   + The seat that opens each betting round is marked in its nameplate (#264)
+  + Optional timestamped diagnostic logging (--log-file): server slow-send /
+    high-ping / slow-action warnings and client frame-stall / slow-audio
+    warnings, all gated by --verbose (#307)
   * regression fix: discard-phase timeout now reports 0 cards drawn (#265)
   * Replace SDL2_net with tcpme (thin POSIX/Winsock wrapper)
   * Fix OpenBSD build (#270)

--- a/src/client.c
+++ b/src/client.c
@@ -74,6 +74,9 @@ static const uint8_t coin_px = 96;
 // What's the max this needs to be to support the unicode suit symbol?
 // SIZEOF_CARD_TEXT is defined in client.h
 
+#define FRAME_HITCH_WARN_MS 250 /* a frame gap >= this => UI stalled (#307) */
+#define AUDIO_SLOW_WARN_MS 500  /* audio engine init/uninit blocking >= this (#307) */
+
 #define MAX_POT_COINS 60
 #define MAX_COIN_IMAGES 16
 
@@ -1297,7 +1300,18 @@ static EGameLogicResult_t handle_game_logic(const PlayerConfig_t *player_config,
   const int8_t my_id = game_settings->client_id;
   tcpme_socket_t sock = socket_context->sock;
 
+  /* Frame-hitch detection: the loop renders continuously, so a large gap
+   * between consecutive frame starts means the main thread stalled (a freeze).
+   * Catches network/audio/render blocks the server can't see. (#307) */
+  uint32_t dc_last_frame = SDL_GetTicks();
+
   while (running) {
+    uint32_t dc_frame_now = SDL_GetTicks();
+    uint32_t dc_frame_dt = dc_frame_now - dc_last_frame;
+    if (dc_frame_dt >= FRAME_HITCH_WARN_MS)
+      dc_log(DC_LOG_WARN, "frame stall: %ums (client UI was unresponsive)", dc_frame_dt);
+    dc_last_frame = dc_frame_now;
+
     POKEVAL_Hand_9 prev_hands[MAX_PLAYERS];
     for (int i = 0; i < MAX_PLAYERS; i++)
       prev_hands[i] = game_state->player[i].hand;
@@ -2223,7 +2237,11 @@ typedef struct {
 
 static int audio_init_thread_fn(void *data) {
   AudioInitAttempt_t *aa = data;
+  uint32_t t0 = SDL_GetTicks();
   aa->result = ma_engine_init(&aa->engineConfig, aa->engine);
+  uint32_t took = SDL_GetTicks() - t0;
+  if (took >= AUDIO_SLOW_WARN_MS)
+    dc_log(DC_LOG_WARN, "audio engine init took %ums (slow audio backend)", took);
   SDL_AtomicSet(&aa->done, 1);
   return 0;
 }
@@ -2235,7 +2253,11 @@ typedef struct {
 
 static int audio_uninit_thread_fn(void *data) {
   AudioUninitAttempt_t *au = data;
+  uint32_t t0 = SDL_GetTicks();
   ma_engine_uninit(au->engine);
+  uint32_t took = SDL_GetTicks() - t0;
+  if (took >= AUDIO_SLOW_WARN_MS)
+    dc_log(DC_LOG_WARN, "audio engine uninit took %ums (slow audio backend)", took);
   SDL_AtomicSet(&au->done, 1);
   return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -920,6 +920,7 @@ static CliArgs_t parse_cli_args(int argc, char *argv[]) {
     OPT_AUTODEAL,
     OPT_AUTO_CONNECT,
     OPT_CARD_PREVIEW,
+    OPT_LOG_FILE,
   };
 
   static const glopt_option_t options[] = {
@@ -938,6 +939,7 @@ static CliArgs_t parse_cli_args(int argc, char *argv[]) {
       {"autodeal", GLOPT_NO_ARG, OPT_AUTODEAL, 0},
       {"auto-connect", GLOPT_NO_ARG, OPT_AUTO_CONNECT, 0},
       {"card-preview", GLOPT_NO_ARG, OPT_CARD_PREVIEW, 0},
+      {"log-file", GLOPT_REQUIRED_ARG, OPT_LOG_FILE, 0},
       {NULL, 0, 0, 0}};
 
   glopt_parser_t parser;
@@ -1000,6 +1002,9 @@ static CliArgs_t parse_cli_args(int argc, char *argv[]) {
     case OPT_CARD_PREVIEW:
       cli_args.card_preview = true;
       break;
+    case OPT_LOG_FILE:
+      dc_log_set_file(parser.optarg);
+      break;
     case '?':
     default:
       print_version();
@@ -1012,6 +1017,8 @@ static CliArgs_t parse_cli_args(int argc, char *argv[]) {
             "  --host [IP]\n"
             "  --port [port]\n"
             "  --disable-audio\n"
+            "  --log-file [path]          Write timestamped diagnostics to a file (useful for GUI "
+            "clients with no console)\n"
             "  --version\n"
             "\n"
             "Testing options:\n"

--- a/src/server.c
+++ b/src/server.c
@@ -94,6 +94,15 @@ static bool rate_limit_check(const char *ip_str, uint32_t max_per_minute) {
 
 #define PING_THRESHOLD 1000
 
+/* Network-health diagnostics (#307), all gated behind --verbose via dc_log.
+ * Thresholds are tunable; they flag anomalies, not every message. */
+#define SLOW_SEND_WARN_MS 200  /* a send blocking this long => client not draining */
+#define PING_SPIKE_WARN_MS 500 /* lobby ping above this => flaky/parked link */
+/* Deliberately high: normal deliberation (and bots' 2-10s delays) routinely
+ * exceed a few seconds, so only flag waits long enough to suggest a real stall
+ * rather than thinking. (action_timeout defaults to 30s.) */
+#define RECV_WAIT_WARN_MS 15000 /* waited this long for a player's input */
+
 #define handle_round() handle_round_real(args, 0, -1)
 #define handle_round_bringin(amt, paid_id) handle_round_real(args, (amt), (paid_id))
 
@@ -403,10 +412,16 @@ static void broadcast_game_state(ArgsBroadcastGameState_t *args) {
     uint32_t size_net = SDL_SwapBE32((uint32_t)size);
 
     // fprintf(stderr, "sending to %d\n", i);
+    uint32_t send_start = SDL_GetTicks();
     if (send_all_tcp(args->clients[i], &size_net, sizeof(size_net)) != 0 ||
         send_all_tcp(args->clients[i], data, size) != 0) {
       fprintf(stderr, "Failed to send game state to client %d\n", i);
       handle_disconnections(args);
+    } else {
+      uint32_t send_ms = SDL_GetTicks() - send_start;
+      if (send_ms >= SLOW_SEND_WARN_MS)
+        dc_log(DC_LOG_WARN, "slow game-state send to client %d: %ums (client not draining its socket?)",
+               i, send_ms);
     }
     free(data);
   }
@@ -814,6 +829,13 @@ static ELoop_t handle_draw(ArgsBroadcastGameState_t *args, tcpme_socket_t sock, 
     break;
   }
 
+  if (!timed_out) {
+    uint32_t waited = SDL_GetTicks() - start;
+    if (waited >= RECV_WAIT_WARN_MS)
+      dc_log(DC_LOG_WARN, "waited %ums for player %d's draw (slow input or stalled link)", waited,
+             id);
+  }
+
   uint8_t count = buffer[2];
   if (count > MAX_DISCARDS)
     return LOOP_ERROR;
@@ -1123,6 +1145,13 @@ static RoundResults handle_round_real(ArgsBroadcastGameState_t *args, uint32_t i
           continue;
         }
       }
+    }
+
+    if (action.action != 0) {
+      uint32_t waited = SDL_GetTicks() - start;
+      if (waited >= RECV_WAIT_WARN_MS)
+        dc_log(DC_LOG_WARN, "waited %ums for player %d's action (slow input or stalled link)", waited,
+               turn->id);
     }
 
     char status_str[LEN_STATUS_STR] = {0};
@@ -2383,6 +2412,8 @@ int run_server(const CliArgs_t *cli_args, Path_t *path) {
             } else {
               now = SDL_GetTicks();
               ping_times[i] = now - resp->timestamp;
+              if (ping_times[i] >= PING_SPIKE_WARN_MS)
+                dc_log(DC_LOG_WARN, "high ping from client %d: %ums", i, ping_times[i]);
               ping_response__free_unpacked(resp, NULL);
             }
             break;

--- a/src/util.c
+++ b/src/util.c
@@ -28,10 +28,12 @@
 
 #include <errno.h>
 #include <limits.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <time.h>
 
 #ifdef _WIN32
 // clang-format off
@@ -191,6 +193,52 @@ void verbose_printf(const char *fmt, ...) {
 void verbose_puts(const char *s) {
   if (verbose && s)
     puts(s);
+}
+
+static FILE *dc_log_fp = NULL; /* NULL => stderr */
+
+static void dc_log_close(void) {
+  if (dc_log_fp) {
+    if (fclose(dc_log_fp) != 0)
+      fprintf(stderr, "dc_log: error closing log file: %s\n", strerror(errno));
+    dc_log_fp = NULL;
+  }
+}
+
+void dc_log_set_file(const char *path) {
+  FILE *f = fopen(path, "a");
+  if (!f) {
+    fprintf(stderr, "dc_log: cannot open log file %s: %s\n", path, strerror(errno));
+    return;
+  }
+  setvbuf(f, NULL, _IOLBF, 0); /* line-buffered so a crash still leaves the log */
+  dc_log_fp = f;
+  atexit(dc_log_close); /* flush + checked close at normal exit */
+}
+
+void dc_log(DCLogLevel_t level, const char *fmt, ...) {
+  if (level != DC_LOG_ERROR && !verbose)
+    return;
+
+  static const char *const tag[] = {"INFO", "WARN", "ERROR"};
+  FILE *out = dc_log_fp ? dc_log_fp : stderr;
+
+  time_t now = time(NULL);
+  struct tm tmv;
+#ifdef _WIN32
+  localtime_s(&tmv, &now);
+#else
+  localtime_r(&now, &tmv);
+#endif
+  char ts[20];
+  strftime(ts, sizeof ts, "%Y-%m-%d %H:%M:%S", &tmv);
+
+  fprintf(out, "%s [%s] ", ts, tag[level]);
+  va_list args;
+  va_start(args, fmt);
+  vfprintf(out, fmt, args);
+  va_end(args);
+  fputc('\n', out);
 }
 
 void parse_signed(const char *s, long minv, long maxv, long *out) {

--- a/src/util.h
+++ b/src/util.h
@@ -67,6 +67,25 @@ void verbose_printf(const char *fmt, ...);
 
 void verbose_puts(const char *s);
 
+typedef enum {
+  DC_LOG_INFO,
+  DC_LOG_WARN,
+  DC_LOG_ERROR,
+} DCLogLevel_t;
+
+/* Timestamped logger: prints "YYYY-MM-DD HH:MM:SS [LEVEL] <msg>\n" to stderr.
+ * INFO and WARN are gated by --verbose; ERROR always prints. The message must
+ * NOT include a trailing newline (dc_log appends one). */
+#if defined(__GNUC__)
+void dc_log(DCLogLevel_t level, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+#else
+void dc_log(DCLogLevel_t level, const char *fmt, ...);
+#endif
+
+/* Redirect dc_log output to a file (appended, line-buffered). Used by
+ * --log-file, mainly so GUI clients with no console can capture diagnostics. */
+void dc_log_set_file(const char *path);
+
 void parse_signed(const char *s, long minv, long maxv, long *out);
 
 void parse_unsigned(const char *s, unsigned long maxv, unsigned long *out);


### PR DESCRIPTION
…gs (#307)

> Commit message drafted by Claude (Opus 4.8), an LLM by Anthropic, at @andy5995's direction.

Adds dc_log (timestamped, level-gated, optional --log-file with checked open/close) and uses it for verbose-only anomaly warnings: server slow-send / high-ping / slow-action, and client frame-stall / slow-audio. --log-file lets GUI clients with no console capture diagnostics for remote bug reports.