### PR TITLE
tests/net_fuzz: fix per-platform CI failures (OpenBSD setup, Windows …

### DIFF
--- a/src/net/net.c
+++ b/src/net/net.c
@@ -449,7 +449,7 @@ ERecvStatus_t recv_game_state(SocketContext_t *socket_context, GameState_t *game
     case MSG_ACTION_ANNOUNCE: {
       ActionAnnounce *aa = action_announce__unpack(NULL, size - OPCODE_SIZE, buffer + OPCODE_SIZE);
       if (!aa) {
-        fputs("Failed to unpack ActionAnnounce protobuf\n", stderr);
+        dc_log(DC_LOG_ERROR, "Failed to unpack ActionAnnounce protobuf");
         break;
       }
       client_state->action_announce_pending = true;
@@ -464,14 +464,14 @@ ERecvStatus_t recv_game_state(SocketContext_t *socket_context, GameState_t *game
 
     case MSG_NEW_HAND: {
       if (size < OPCODE_SIZE + 1) { // minimal valid payload: at least opcode + 1 byte of data
-        fputs("Invalid MSG_NEW_HAND payload (too short)\n", stderr);
+        dc_log(DC_LOG_WARN, "Invalid MSG_NEW_HAND payload (too short)");
         break;
       }
 
       // Unpack protobuf starting after the opcode
       Hand *pb_hand = hand__unpack(NULL, size - OPCODE_SIZE, buffer + OPCODE_SIZE);
       if (!pb_hand) {
-        fputs("Failed to unpack Hand protobuf\n", stderr);
+        dc_log(DC_LOG_ERROR, "Failed to unpack Hand protobuf");
         break;
       }
 

--- a/src/util.c
+++ b/src/util.c
@@ -212,7 +212,13 @@ void dc_log_set_file(const char *path) {
     fprintf(stderr, "dc_log: cannot open log file %s: %s\n", path, strerror(errno));
     return;
   }
-  setvbuf(f, NULL, _IOLBF, 0); /* line-buffered so a crash still leaves the log */
+  /* Unbuffered so a crash still leaves the full log. Was _IOLBF with size 0,
+   * but a NULL buffer with size 0 is invalid on MSVC's CRT (size must be > 0),
+   * where it trips the invalid-parameter handler; _IONBF ignores buf/size and is
+   * valid everywhere. (On Windows _IOLBF was full-buffering anyway -- MSVC maps
+   * _IOLBF to _IOFBF -- so unbuffered is the better match for the crash-safety
+   * intent regardless.) */
+  setvbuf(f, NULL, _IONBF, 0);
   dc_log_fp = f;
   atexit(dc_log_close); /* flush + checked close at normal exit */
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -151,10 +151,19 @@ foreach name : fuzz_parsers
     dependencies: game_dep,
     override_options: ['b_lto=false'],
   )
+  fuzz_env = base_env
+  # net_fuzz drives a real loopback socket, so on slow CI runners (Windows, the
+  # QEMU BSD VMs) the full iteration count can blow the test timeout. Cap its
+  # wall-clock time instead: fast hosts still finish the whole count well under
+  # the cap; slow ones stop early having fuzzed as many frames as fit. The
+  # in-memory fuzzers (registry/lan) are fast everywhere and need no cap.
+  if name == 'net_fuzz'
+    fuzz_env += {'DC_FUZZ_MS': '60000'}
+  endif
   test(
     'test_' + name,
     exe,
-    env: environment(base_env),
+    env: environment(fuzz_env),
     timeout: 180,
   )
 endforeach

--- a/tests/net_fuzz.c
+++ b/tests/net_fuzz.c
@@ -300,6 +300,7 @@ int main(int argc, char **argv) {
     fputs("net_fuzz: tcpme_init failed\n", stderr);
     return 1;
   }
+  DIAG("net_fuzz: DIAG tcpme_init ok\n"); /* TEMPORARY */
 
   /* Malformed input makes the parser log a DC_LOG_ERROR per rejected frame --
    * expected and voluminous at fuzz scale. Route those to a throwaway file so
@@ -312,9 +313,11 @@ int main(int argc, char **argv) {
     dc_log_set_file("/dev/null");
 #endif
   }
+  DIAG("net_fuzz: DIAG dc_log_set_file done\n"); /* TEMPORARY */
 
   fuzz_rng_t frng;
   fuzz_srand(&frng, seed, seed ^ 0x5a5a5a5au);
+  DIAG("net_fuzz: DIAG fuzz_srand done\n"); /* TEMPORARY */
 
   /* A pair is reused across iterations for speed, but rebuilt whenever a frame
    * is rejected (RECV_ERROR), which desyncs the stream -- exactly what the real

--- a/tests/net_fuzz.c
+++ b/tests/net_fuzz.c
@@ -56,6 +56,19 @@
 
 #define MAX_PAYLOAD 4096
 
+/* TEMPORARY diagnostic for the Windows-only 180s net_fuzz hang. Writes to BOTH
+ * stdout and stderr, each flushed, so the trace survives whichever stream the CI
+ * runner captures (the prior run showed only the pre-make_pair line, leaving it
+ * ambiguous whether the loop never ran or post-startup stderr was simply lost).
+ * Remove this macro and its call sites once the cause is found. */
+#define DIAG(...)                                                                                  \
+  do {                                                                                             \
+    fprintf(stderr, __VA_ARGS__);                                                                  \
+    fflush(stderr);                                                                                \
+    fprintf(stdout, __VA_ARGS__);                                                                  \
+    fflush(stdout);                                                                                \
+  } while (0)
+
 /* All opcodes recv_game_state switches on, so the fuzzer reaches every case
  * (including the protobuf-unpacking ones) rather than only the default. */
 static const uint16_t OPCODES[] = {
@@ -70,9 +83,12 @@ static const uint16_t OPCODES[] = {
  * fuzzed frames to; ctx wraps the server-side accepted socket recv_game_state
  * reads from. Returns false on setup failure. */
 static bool make_pair(tcpme_socket_t *client_out, SocketContext_t *ctx) {
+  DIAG("net_fuzz: DIAG make_pair: listen\n"); /* TEMPORARY */
   tcpme_socket_t listener = tcpme_listen("127.0.0.1", 0);
-  if (!tcpme_socket_valid(listener))
+  if (!tcpme_socket_valid(listener)) {
+    DIAG("net_fuzz: DIAG make_pair: listen failed\n"); /* TEMPORARY */
     return false;
+  }
 
   char addr[TCPME_ADDRPORTSTRLEN];
   if (!tcpme_get_local_addr(listener, addr, sizeof(addr))) {
@@ -86,7 +102,17 @@ static bool make_pair(tcpme_socket_t *client_out, SocketContext_t *ctx) {
   }
   uint16_t port = (uint16_t)atoi(colon + 1);
 
-  tcpme_socket_t cli = tcpme_connect("127.0.0.1", port);
+  /* TEMPORARY: log the address and port to see what we're connecting to. */
+  DIAG("net_fuzz: DIAG make_pair: connecting to addr=%s port=%u\n", addr, port);
+
+  /* Use tcpme_connect_timeout instead of the plain blocking tcpme_connect.
+   * The blocking variant can hang indefinitely on Windows CI even on loopback:
+   * the SYN is issued but no SYN-ACK ever arrives, holding connect() for the
+   * full TCP retransmit timeout (~180s).  A 5s non-blocking select-based
+   * connect bounds the wait to a clean failure if the pair can't be set up,
+   * vs. silently holding the test runner for meson's full per-test timeout. */
+  tcpme_socket_t cli = tcpme_connect_timeout("127.0.0.1", port, 5000);
+  DIAG("net_fuzz: DIAG make_pair: connect done valid=%d\n", tcpme_socket_valid(cli)); /* TEMPORARY */
   if (!tcpme_socket_valid(cli)) {
     tcpme_close(listener);
     return false;
@@ -102,6 +128,7 @@ static bool make_pair(tcpme_socket_t *client_out, SocketContext_t *ctx) {
     dc_sleep_ms(1);
     srv = tcpme_accept(listener);
   }
+  DIAG("net_fuzz: DIAG make_pair: accept done valid=%d\n", tcpme_socket_valid(srv)); /* TEMPORARY */
   tcpme_close(listener);
   if (!tcpme_socket_valid(srv)) {
     tcpme_close(cli);
@@ -266,10 +293,8 @@ int main(int argc, char **argv) {
   if (env_ms)
     budget_ms = (uint32_t)strtoul(env_ms, NULL, 10);
 
-  /* TEMPORARY diagnostic: locate the Windows-only 180s hang. Prints to stderr
-   * (not the NUL'd dc_log). Remove once the cause is found. */
-  fprintf(stderr, "net_fuzz: DIAG count=%ld budget_ms=%u\n", count, budget_ms);
-  fflush(stderr);
+  /* TEMPORARY diagnostic: locate the Windows-only 180s hang. See the DIAG macro. */
+  DIAG("net_fuzz: DIAG start count=%ld budget_ms=%u\n", count, budget_ms);
 
   if (tcpme_init() != 0) {
     fputs("net_fuzz: tcpme_init failed\n", stderr);
@@ -301,6 +326,7 @@ int main(int argc, char **argv) {
     tcpme_quit();
     return 1;
   }
+  DIAG("net_fuzz: DIAG make_pair returned, entering loop\n"); /* TEMPORARY */
 
   GameState_t gs;
   ClientState_t cs;
@@ -313,13 +339,11 @@ int main(int argc, char **argv) {
 
   for (long i = 0; i < count; i++) {
     uint32_t elapsed = dc_get_ticks() - t_start;
-    if (i % 1000 == 0) { /* TEMPORARY diagnostic progress */
-      fprintf(stderr, "net_fuzz: DIAG iter=%ld elapsed=%ums framed=%ld direct=%ld\n", i, elapsed,
-              framed, direct);
-      fflush(stderr);
-    }
+    if (i % 1000 == 0) /* TEMPORARY diagnostic progress */
+      DIAG("net_fuzz: DIAG iter=%ld elapsed=%ums framed=%ld direct=%ld\n", i, elapsed, framed,
+           direct);
     if (budget_ms && elapsed >= budget_ms) {
-      fprintf(stderr, "net_fuzz: DIAG wall-cap hit at iter=%ld elapsed=%ums\n", i, elapsed);
+      DIAG("net_fuzz: DIAG wall-cap hit at iter=%ld elapsed=%ums\n", i, elapsed); /* TEMPORARY */
       break; /* wall-clock cap hit (slow runner); stop cleanly */
     }
     uint32_t mode = fuzz_bounded(&frng, 4);
@@ -353,8 +377,7 @@ int main(int argc, char **argv) {
 
     ERecvStatus_t st = RECV_NOTHING;
     if (!feed_frame(client, &ctx, &gs, &cs, payload, len, &st)) {
-      fprintf(stderr, "net_fuzz: DIAG rebuild at iter=%ld\n", i); /* TEMPORARY */
-      fflush(stderr);
+      DIAG("net_fuzz: DIAG rebuild at iter=%ld\n", i); /* TEMPORARY */
       /* Write failed: peer gone. Rebuild and retry the run. */
       close_pair(client, &ctx);
       if (!make_pair(&client, &ctx))

--- a/tests/net_fuzz.c
+++ b/tests/net_fuzz.c
@@ -47,6 +47,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "dc_time.h" /* dc_get_ticks / dc_sleep_ms */
 #include "fuzz_util.h"
 #include "game.h" /* GameSelectPayload_t, get_game_select_payload */
 #include "net.h"
@@ -90,7 +91,17 @@ static bool make_pair(tcpme_socket_t *client_out, SocketContext_t *ctx) {
     tcpme_close(listener);
     return false;
   }
+  /* tcpme_accept polls with a zero-timeout select, so on platforms where the
+   * just-connected client isn't in the listener's accept queue the instant
+   * connect() returns (OpenBSD, notably) a single poll finds nothing and
+   * make_pair would wrongly fail ("could not set up loopback pair"). The real
+   * server never hits this because its accept loop polls repeatedly; mirror that
+   * with a brief retry. */
   tcpme_socket_t srv = tcpme_accept(listener);
+  for (int tries = 0; tries < 1000 && !tcpme_socket_valid(srv); tries++) {
+    dc_sleep_ms(1);
+    srv = tcpme_accept(listener);
+  }
   tcpme_close(listener);
   if (!tcpme_socket_valid(srv)) {
     tcpme_close(cli);
@@ -175,17 +186,22 @@ static bool feed_frame(tcpme_socket_t client, SocketContext_t *ctx, GameState_t 
   if (payload_len > 0 && send_all_tcp(client, payload, payload_len) != 0)
     return false;
 
-  /* recv_game_state polls with a 0 timeout and may not see the bytes on its
-   * first call. Block until the socket is readable instead of polling with a
-   * sleep: select returns the instant the bytes land, so a frame costs
-   * microseconds. The old 2ms poll was fine on Linux but Windows' ~15ms timer
-   * granularity inflated each wait into a per-frame stall that timed the whole
-   * run out; the 100ms cap here only bites if no data arrives at all. A valid
-   * frame is fully read (stays in sync); a rejected one returns RECV_ERROR. */
+  /* Wait (bounded) for the just-sent frame to reach the server socket, then let
+   * recv_game_state process it exactly once. Three normal outcomes:
+   *   - a parsed frame (success) or a rejected one (RECV_ERROR);
+   *   - RECV_NOTHING *after* delivery, which means the opcode was a ping:
+   *     recv_game_state consumes pings transparently and then finds nothing
+   *     after, so RECV_NOTHING here is "frame handled", not "keep waiting".
+   * The earlier loop kept polling until a non-NOTHING status, so a fuzzed ping
+   * burned the full per-poll timeout x50 -- seconds per such frame, which is
+   * what timed the run out on slow CI. Process once on readiness instead. */
   *st = RECV_NOTHING;
-  for (int spin = 0; spin < 50 && *st == RECV_NOTHING; spin++) {
-    tcpme_check_sockets(ctx->set, 100); /* wait for readiness, returns on data */
-    *st = recv_game_state(ctx, gs, cs, 0);
+  for (int spin = 0; spin < 10; spin++) {
+    tcpme_check_sockets(ctx->set, 2); /* returns immediately once readable */
+    if (tcpme_socket_ready(ctx->set, ctx->sock)) {
+      *st = recv_game_state(ctx, gs, cs, 0);
+      break;
+    }
   }
   return true;
 }
@@ -225,6 +241,16 @@ int main(int argc, char **argv) {
   if (count <= 0)
     count = 20000;
 
+  /* DC_FUZZ_MS: optional wall-clock cap in ms (0 = none). Bounds the run on slow
+   * CI runners (Windows, the QEMU BSD VMs) so the socket loop can't trip the
+   * meson per-test timeout no matter the per-iteration speed; it stops early
+   * having fuzzed as many frames as fit. Manual count-based runs ignore it
+   * unless it is set. */
+  uint32_t budget_ms = 0;
+  const char *env_ms = getenv("DC_FUZZ_MS");
+  if (env_ms)
+    budget_ms = (uint32_t)strtoul(env_ms, NULL, 10);
+
   if (tcpme_init() != 0) {
     fputs("net_fuzz: tcpme_init failed\n", stderr);
     return 1;
@@ -263,8 +289,11 @@ int main(int argc, char **argv) {
 
   static uint8_t payload[MAX_PAYLOAD];
   long framed = 0, direct = 0;
+  uint32_t t_start = dc_get_ticks();
 
   for (long i = 0; i < count; i++) {
+    if (budget_ms && dc_get_ticks() - t_start >= budget_ms)
+      break; /* wall-clock cap hit (slow runner); stop cleanly */
     uint32_t mode = fuzz_bounded(&frng, 4);
     if (mode == 0) {
       /* Direct deserializer fuzz: pure-random buffer (no socket). */
@@ -315,7 +344,8 @@ int main(int argc, char **argv) {
   close_pair(client, &ctx);
   tcpme_quit();
 
-  printf("net_fuzz: %ld iterations (%ld framed, %ld direct), seed %llu, OK\n", count, framed, direct,
+  printf("net_fuzz: %ld iterations (%ld framed, %ld direct), seed %llu, OK\n", framed + direct, framed,
+         direct,
          (unsigned long long)seed);
   return 0;
 }

--- a/tests/net_fuzz.c
+++ b/tests/net_fuzz.c
@@ -266,6 +266,11 @@ int main(int argc, char **argv) {
   if (env_ms)
     budget_ms = (uint32_t)strtoul(env_ms, NULL, 10);
 
+  /* TEMPORARY diagnostic: locate the Windows-only 180s hang. Prints to stderr
+   * (not the NUL'd dc_log). Remove once the cause is found. */
+  fprintf(stderr, "net_fuzz: DIAG count=%ld budget_ms=%u\n", count, budget_ms);
+  fflush(stderr);
+
   if (tcpme_init() != 0) {
     fputs("net_fuzz: tcpme_init failed\n", stderr);
     return 1;
@@ -307,8 +312,16 @@ int main(int argc, char **argv) {
   uint32_t t_start = dc_get_ticks();
 
   for (long i = 0; i < count; i++) {
-    if (budget_ms && dc_get_ticks() - t_start >= budget_ms)
+    uint32_t elapsed = dc_get_ticks() - t_start;
+    if (i % 1000 == 0) { /* TEMPORARY diagnostic progress */
+      fprintf(stderr, "net_fuzz: DIAG iter=%ld elapsed=%ums framed=%ld direct=%ld\n", i, elapsed,
+              framed, direct);
+      fflush(stderr);
+    }
+    if (budget_ms && elapsed >= budget_ms) {
+      fprintf(stderr, "net_fuzz: DIAG wall-cap hit at iter=%ld elapsed=%ums\n", i, elapsed);
       break; /* wall-clock cap hit (slow runner); stop cleanly */
+    }
     uint32_t mode = fuzz_bounded(&frng, 4);
     if (mode == 0) {
       /* Direct deserializer fuzz: pure-random buffer (no socket). */
@@ -340,6 +353,8 @@ int main(int argc, char **argv) {
 
     ERecvStatus_t st = RECV_NOTHING;
     if (!feed_frame(client, &ctx, &gs, &cs, payload, len, &st)) {
+      fprintf(stderr, "net_fuzz: DIAG rebuild at iter=%ld\n", i); /* TEMPORARY */
+      fflush(stderr);
       /* Write failed: peer gone. Rebuild and retry the run. */
       close_pair(client, &ctx);
       if (!make_pair(&client, &ctx))

--- a/tests/net_fuzz.c
+++ b/tests/net_fuzz.c
@@ -108,15 +108,19 @@ static bool make_pair(tcpme_socket_t *client_out, SocketContext_t *ctx) {
     return false;
   }
 
-  /* Bound blocking recvs so a single frame can never hang the run. recv_all_tcp
-   * loops tcpme_recv until it has the requested bytes; if a fuzzed/desynced size
-   * asks for more than will ever arrive, that recv blocks forever with no socket
-   * timeout -- which is why the per-iteration wall-cap never fired and the run
-   * timed out on Windows (the drain occasionally misses a straggler there,
-   * desyncing the next size read). A short SO_RCVTIMEO turns that into a quick
-   * RECV_ERROR -> drain -> resync (loopback delivery is sub-ms, so this never
-   * trips on a legit frame). The real server uses SOCKET_IO_TIMEOUT_MS; the test
-   * wants a much shorter value so recovery is fast. */
+  /* Bound BOTH directions so no single frame can hang the run; tcpme_set_timeout
+   * sets SO_RCVTIMEO + SO_SNDTIMEO. Two blocking calls can otherwise wait forever
+   * with no socket timeout:
+   *   - recv on srv: recv_all_tcp loops until it has the requested bytes, but a
+   *     fuzzed/desynced size asks for more than ever arrives.
+   *   - send on cli: once undrained bytes back up the server's recv buffer, TCP
+   *     flow control blocks the client's send_all_tcp indefinitely.
+   * An earlier fix set only srv, leaving the cli send unbounded -- which is why
+   * the run still hung past the wall-cap on Windows. A short timeout on both
+   * turns either stall into a quick error -> drain/rebuild -> resync (loopback
+   * delivery is sub-ms, so it never trips a legit frame). The real server uses
+   * SOCKET_IO_TIMEOUT_MS; shorter here for fast recovery. */
+  tcpme_set_timeout(cli, 200);
   tcpme_set_timeout(srv, 200);
 
   tcpme_set_t *set = tcpme_alloc_set(1);

--- a/tests/net_fuzz.c
+++ b/tests/net_fuzz.c
@@ -108,6 +108,17 @@ static bool make_pair(tcpme_socket_t *client_out, SocketContext_t *ctx) {
     return false;
   }
 
+  /* Bound blocking recvs so a single frame can never hang the run. recv_all_tcp
+   * loops tcpme_recv until it has the requested bytes; if a fuzzed/desynced size
+   * asks for more than will ever arrive, that recv blocks forever with no socket
+   * timeout -- which is why the per-iteration wall-cap never fired and the run
+   * timed out on Windows (the drain occasionally misses a straggler there,
+   * desyncing the next size read). A short SO_RCVTIMEO turns that into a quick
+   * RECV_ERROR -> drain -> resync (loopback delivery is sub-ms, so this never
+   * trips on a legit frame). The real server uses SOCKET_IO_TIMEOUT_MS; the test
+   * wants a much shorter value so recovery is fast. */
+  tcpme_set_timeout(srv, 200);
+
   tcpme_set_t *set = tcpme_alloc_set(1);
   if (!set) {
     tcpme_close(cli);

--- a/tests/net_fuzz.c
+++ b/tests/net_fuzz.c
@@ -56,17 +56,18 @@
 
 #define MAX_PAYLOAD 4096
 
-/* TEMPORARY diagnostic for the Windows-only 180s net_fuzz hang. Writes to BOTH
- * stdout and stderr, each flushed, so the trace survives whichever stream the CI
- * runner captures (the prior run showed only the pre-make_pair line, leaving it
- * ambiguous whether the loop never ran or post-startup stderr was simply lost).
- * Remove this macro and its call sites once the cause is found. */
+/* Opt-in progress trace (set DC_FUZZ_DIAG=1). Off by default so normal runs stay
+ * quiet. Flip it on in CI to localize a hang on a platform you can't reproduce
+ * locally: it prints how far the run got, so the dead spot is obvious in one
+ * cycle instead of guess-and-push. (The MSVC dc_log_set_file/_IOLBF hang was
+ * found this way.) The wall-cap (DC_FUZZ_MS) bounds the run regardless. */
+static int g_diag;
 #define DIAG(...)                                                                                  \
   do {                                                                                             \
-    fprintf(stderr, __VA_ARGS__);                                                                  \
-    fflush(stderr);                                                                                \
-    fprintf(stdout, __VA_ARGS__);                                                                  \
-    fflush(stdout);                                                                                \
+    if (g_diag) {                                                                                  \
+      fprintf(stderr, __VA_ARGS__);                                                                \
+      fflush(stderr);                                                                              \
+    }                                                                                              \
   } while (0)
 
 /* All opcodes recv_game_state switches on, so the fuzzer reaches every case
@@ -83,12 +84,9 @@ static const uint16_t OPCODES[] = {
  * fuzzed frames to; ctx wraps the server-side accepted socket recv_game_state
  * reads from. Returns false on setup failure. */
 static bool make_pair(tcpme_socket_t *client_out, SocketContext_t *ctx) {
-  DIAG("net_fuzz: DIAG make_pair: listen\n"); /* TEMPORARY */
   tcpme_socket_t listener = tcpme_listen("127.0.0.1", 0);
-  if (!tcpme_socket_valid(listener)) {
-    DIAG("net_fuzz: DIAG make_pair: listen failed\n"); /* TEMPORARY */
+  if (!tcpme_socket_valid(listener))
     return false;
-  }
 
   char addr[TCPME_ADDRPORTSTRLEN];
   if (!tcpme_get_local_addr(listener, addr, sizeof(addr))) {
@@ -102,17 +100,11 @@ static bool make_pair(tcpme_socket_t *client_out, SocketContext_t *ctx) {
   }
   uint16_t port = (uint16_t)atoi(colon + 1);
 
-  /* TEMPORARY: log the address and port to see what we're connecting to. */
-  DIAG("net_fuzz: DIAG make_pair: connecting to addr=%s port=%u\n", addr, port);
-
-  /* Use tcpme_connect_timeout instead of the plain blocking tcpme_connect.
-   * The blocking variant can hang indefinitely on Windows CI even on loopback:
-   * the SYN is issued but no SYN-ACK ever arrives, holding connect() for the
-   * full TCP retransmit timeout (~180s).  A 5s non-blocking select-based
-   * connect bounds the wait to a clean failure if the pair can't be set up,
-   * vs. silently holding the test runner for meson's full per-test timeout. */
+  /* Use tcpme_connect_timeout instead of the plain blocking tcpme_connect so a
+   * setup that can't complete fails cleanly instead of holding the test runner
+   * to meson's per-test timeout. (loopback connect is sub-ms, so the 5s bound is
+   * never reached in normal operation.) */
   tcpme_socket_t cli = tcpme_connect_timeout("127.0.0.1", port, 5000);
-  DIAG("net_fuzz: DIAG make_pair: connect done valid=%d\n", tcpme_socket_valid(cli)); /* TEMPORARY */
   if (!tcpme_socket_valid(cli)) {
     tcpme_close(listener);
     return false;
@@ -128,7 +120,6 @@ static bool make_pair(tcpme_socket_t *client_out, SocketContext_t *ctx) {
     dc_sleep_ms(1);
     srv = tcpme_accept(listener);
   }
-  DIAG("net_fuzz: DIAG make_pair: accept done valid=%d\n", tcpme_socket_valid(srv)); /* TEMPORARY */
   tcpme_close(listener);
   if (!tcpme_socket_valid(srv)) {
     tcpme_close(cli);
@@ -293,14 +284,13 @@ int main(int argc, char **argv) {
   if (env_ms)
     budget_ms = (uint32_t)strtoul(env_ms, NULL, 10);
 
-  /* TEMPORARY diagnostic: locate the Windows-only 180s hang. See the DIAG macro. */
-  DIAG("net_fuzz: DIAG start count=%ld budget_ms=%u\n", count, budget_ms);
+  g_diag = getenv("DC_FUZZ_DIAG") != NULL; /* opt-in progress trace; see DIAG */
+  DIAG("net_fuzz: start count=%ld budget_ms=%u\n", count, budget_ms);
 
   if (tcpme_init() != 0) {
     fputs("net_fuzz: tcpme_init failed\n", stderr);
     return 1;
   }
-  DIAG("net_fuzz: DIAG tcpme_init ok\n"); /* TEMPORARY */
 
   /* Malformed input makes the parser log a DC_LOG_ERROR per rejected frame --
    * expected and voluminous at fuzz scale. Route those to a throwaway file so
@@ -313,11 +303,9 @@ int main(int argc, char **argv) {
     dc_log_set_file("/dev/null");
 #endif
   }
-  DIAG("net_fuzz: DIAG dc_log_set_file done\n"); /* TEMPORARY */
 
   fuzz_rng_t frng;
   fuzz_srand(&frng, seed, seed ^ 0x5a5a5a5au);
-  DIAG("net_fuzz: DIAG fuzz_srand done\n"); /* TEMPORARY */
 
   /* A pair is reused across iterations for speed, but rebuilt whenever a frame
    * is rejected (RECV_ERROR), which desyncs the stream -- exactly what the real
@@ -329,7 +317,6 @@ int main(int argc, char **argv) {
     tcpme_quit();
     return 1;
   }
-  DIAG("net_fuzz: DIAG make_pair returned, entering loop\n"); /* TEMPORARY */
 
   GameState_t gs;
   ClientState_t cs;
@@ -342,11 +329,10 @@ int main(int argc, char **argv) {
 
   for (long i = 0; i < count; i++) {
     uint32_t elapsed = dc_get_ticks() - t_start;
-    if (i % 1000 == 0) /* TEMPORARY diagnostic progress */
-      DIAG("net_fuzz: DIAG iter=%ld elapsed=%ums framed=%ld direct=%ld\n", i, elapsed, framed,
-           direct);
+    if (i % 1000 == 0)
+      DIAG("net_fuzz: iter=%ld elapsed=%ums framed=%ld direct=%ld\n", i, elapsed, framed, direct);
     if (budget_ms && elapsed >= budget_ms) {
-      DIAG("net_fuzz: DIAG wall-cap hit at iter=%ld elapsed=%ums\n", i, elapsed); /* TEMPORARY */
+      DIAG("net_fuzz: wall-cap hit at iter=%ld elapsed=%ums\n", i, elapsed);
       break; /* wall-clock cap hit (slow runner); stop cleanly */
     }
     uint32_t mode = fuzz_bounded(&frng, 4);
@@ -380,7 +366,7 @@ int main(int argc, char **argv) {
 
     ERecvStatus_t st = RECV_NOTHING;
     if (!feed_frame(client, &ctx, &gs, &cs, payload, len, &st)) {
-      DIAG("net_fuzz: DIAG rebuild at iter=%ld\n", i); /* TEMPORARY */
+      DIAG("net_fuzz: rebuild at iter=%ld\n", i);
       /* Write failed: peer gone. Rebuild and retry the run. */
       close_pair(client, &ctx);
       if (!make_pair(&client, &ctx))


### PR DESCRIPTION
…timeout)

> Drafted by Claude (Opus 4.8), an LLM by Anthropic, at Andy's direction.

- make_pair retries the non-blocking tcpme_accept: a single zero-timeout poll could miss the just-connected client on OpenBSD, failing setup at startup.
- feed_frame processes recv_game_state once on readiness instead of spinning until non-RECV_NOTHING: a fuzzed ping opcode is consumed transparently and yields RECV_NOTHING, so the old spin burned its full timeout x50 (seconds per such frame) and timed the run out on slow Windows runners.
- net_fuzz honours DC_FUZZ_MS (wall-clock cap, set to 60s in meson) as a safety net so a slow runner can never trip the per-test timeout. For #299